### PR TITLE
61 atnaujinti versijas

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "ioredis": "^5.3.1",
     "knex": "^3.0.1",
     "lodash": "^4.17.21",
-    "moment": "^2.29.4",
     "mime-types": "^2.1.35",
     "minio": "^7.0.33",
     "moleculer": "^0.14.29",
@@ -76,10 +75,10 @@
     "moleculer-postgis": "^0.2.7",
     "moleculer-sentry": "^2.0.0",
     "moleculer-web": "^0.10.5",
+    "moment": "^2.29.4",
     "nats": "^2.13.1",
     "objection": "^3.0.1",
     "pg": "^8.10.0",
-    "postmark": "^3.0.18",
     "transform-coordinates": "^1.0.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1308,13 +1308,6 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-axios@^0.25.0:
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.25.0.tgz#349cfbb31331a9b4453190791760a8d35b093e0a"
-  integrity sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==
-  dependencies:
-    follow-redirects "^1.14.7"
-
 babel-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.7.0.tgz#f4369919225b684c56085998ac63dbd05be020d5"
@@ -1390,7 +1383,6 @@ base64-js@^1.3.1:
   resolved "https://codeload.github.com/DadPatch/biip-auth-nodejs/tar.gz/45a9e7d0051bde0e247d735948faf16c967e2422"
   dependencies:
     isomorphic-unfetch "^3.1.0"
-    qs "^6.11.2"
 
 bl@^4.1.0:
   version "4.1.0"
@@ -2506,11 +2498,6 @@ flatted@^3.2.9:
   version "3.2.9"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
-
-follow-redirects@^1.14.7:
-  version "1.15.3"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
-  integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
 
 for-each@^0.3.3:
   version "0.3.3"
@@ -4612,13 +4599,6 @@ postgres-interval@^1.1.0:
   integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
   dependencies:
     xtend "^4.0.0"
-
-postmark@^3.0.18:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/postmark/-/postmark-3.1.2.tgz#16fb7b36906d9fb0056f3c1127ed9fc5721bb476"
-  integrity sha512-nm5vZR75Fk7coboWVMysq6eWZHMOUZAXOl+JXD3O1rzjOlZ9eYYq++/WyrheTyl0L4h97XJkftanFVU7OCTCDw==
-  dependencies:
-    axios "^0.25.0"
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
follow-redirects bumpas nebereikalingas, nes jis yra postmark dependenciu medyje ir buvo isimtas kartu su postmark