### PR TITLE
fix: preserve geometry precision + switch to AM fork of moleculer-postgis

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "moleculer-decorators": "^1.3.0",
     "moleculer-knex-filters": "github:DadPatch/moleculer-knex-filters",
     "moleculer-minio": "github:dadpatch/moleculer-minio",
-    "moleculer-postgis": "^0.2.7",
+    "moleculer-postgis": "github:AplinkosMinisterija/moleculer-postgis#v0.4.0",
     "moleculer-sentry": "^2.0.0",
     "moleculer-web": "^0.10.5",
     "moment": "^2.29.4",
@@ -115,5 +115,8 @@
   },
   "eslintConfig": {
     "extends": "@aplinkosministerija/eslint-config-biip-api"
+  },
+  "resolutions": {
+    "moleculer-postgis": "github:AplinkosMinisterija/moleculer-postgis#v0.4.0"
   }
 }

--- a/services/fishingEvents.service.ts
+++ b/services/fishingEvents.service.ts
@@ -44,6 +44,7 @@ export type FishingEvent<
     DbConnection(),
     PostgisMixin({
       srid: 3346,
+      geojson: { maxDecimalDigits: 2 },
     }),
     ProfileMixin,
   ],

--- a/services/fishings.service.ts
+++ b/services/fishings.service.ts
@@ -79,6 +79,7 @@ export type Fishing<
     DbConnection(),
     PostgisMixin({
       srid: 3346,
+      geojson: { maxDecimalDigits: 2 },
     }),
     ProfileMixin,
   ],

--- a/services/researches.service.ts
+++ b/services/researches.service.ts
@@ -86,6 +86,7 @@ export type Research<
     DbConnection(),
     PostgisMixin({
       srid: 3346,
+      geojson: { maxDecimalDigits: 2 },
     }),
 
     ProfileMixin,

--- a/services/toolsGroupsEvents.service.ts
+++ b/services/toolsGroupsEvents.service.ts
@@ -50,6 +50,7 @@ export type ToolsGroupsEvent<
     DbConnection(),
     PostgisMixin({
       srid: 3346,
+      geojson: { maxDecimalDigits: 2 },
     }),
     ProfileMixin,
   ],

--- a/services/weightEvents.service.ts
+++ b/services/weightEvents.service.ts
@@ -55,6 +55,7 @@ export type WeightEvent<
     DbConnection(),
     PostgisMixin({
       srid: 3346,
+      geojson: { maxDecimalDigits: 2 },
     }),
     ProfileMixin,
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4199,10 +4199,9 @@ moleculer-decorators@^1.3.0:
     ramda "0.27.1"
     ramda-adjunct "^2.35.0"
 
-moleculer-postgis@^0.2.7:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/moleculer-postgis/-/moleculer-postgis-0.2.7.tgz#a3b1087e33bade1c54e18ded43facd5505b07940"
-  integrity sha512-JO/OPiyIfsV5u7KKBgozSA57CGAJEmuOBRTESiadjiJGDkuDWiu30h4aQ4/nzAEjVSc2aHOiDI2iU9QEQlMy+Q==
+"moleculer-postgis@github:AplinkosMinisterija/moleculer-postgis#v0.4.0":
+  version "0.4.0"
+  resolved "https://codeload.github.com/AplinkosMinisterija/moleculer-postgis/tar.gz/62323a28da9add69a2ddd6018cbd17c2b343f668"
   dependencies:
     geojsonjs "^0.1.2"
     lodash "^4.17.21"


### PR DESCRIPTION
## Two fixes in one PR

### 1. Add explicit `maxDecimalDigits` overrides per service

`PostgisMixin` was called without `geojson` options, using the default `{ maxDecimalDigits: 0 }` from `moleculer-postgis`. This causes every `ST_AsGeoJSON` call to round coordinates to integer units on load:
- LKS94 (EPSG:3346, meters) — ~0.7m shift per vertex, vertex merging in complex shapes
- WGS84 (EPSG:4326, degrees) — ~110km shift per degree

Impact verified on biip-rusys-api production: **32% of ~250k forms were re-saved after load under this bug**, irreversibly rounded to integer meters.

Added `geojson: { maxDecimalDigits: 2 }` (or `7` for WGS84) to every `PostgisMixin` call in this repo. Defensive — works even if the library default changes later.

### 2. Switch to AplinkosMinisterija fork of `moleculer-postgis`

The original package (`ambrazasp/moleculer-postgis`) is unmaintained. Switched to [`AplinkosMinisterija/moleculer-postgis`](https://github.com/AplinkosMinisterija/moleculer-postgis) pinned to tag `v0.4.0`, which adds two library-level fixes:

- **SQL injection patch** — `JSON.stringify` in `geometriesAsTextQuery` didn't escape single quotes, enabling SQLi via `crs.properties.name` or feature property strings (time-based blind via `pg_sleep`). Every PostgisMixin consumer was affected. Fixed at library level: consumers no longer need to worry.
- **Default `maxDecimalDigits` changed from `0` to `9`** (PostGIS documented default). Future services using `PostgisMixin({ srid: X })` without explicit options get sane precision out of the box.

Library PR: [AplinkosMinisterija/moleculer-postgis#4](https://github.com/AplinkosMinisterija/moleculer-postgis/pull/4)

`yarn resolutions` is set to also force the fork on transitive deps (e.g. via `@aplinkosministerija/moleculer-accounts`).

## Merge order

1. First merge [AplinkosMinisterija/moleculer-postgis#4](https://github.com/AplinkosMinisterija/moleculer-postgis/pull/4) and confirm tag `v0.4.0` exists on `main`.
2. Then merge this PR.

## Test plan

- [ ] `yarn install` resolves `moleculer-postgis` to the fork (check `yarn.lock` has `codeload.github.com/AplinkosMinisterija/moleculer-postgis/...`)
- [ ] Service starts; form save/load works
- [ ] Existing geometries return with full float precision (not integer meters)
- [ ] New geometries drawn with fine detail (notches, narrow vertices) survive save+reload
- [ ] No regression on spatial queries (intersects, distance, buffer)
