### PR TITLE
fix: allow ending fishing when preliminary catches are all empty

### DIFF
--- a/services/fishings.service.ts
+++ b/services/fishings.service.ts
@@ -334,9 +334,15 @@ export default class FishTypesService extends moleculer.Service {
         fishing: current.id,
       },
     });
-    const finalFishEvent = fishWeightEvents.find((fishEvenet) => !fishEvenet.toolsGroup);
+    const finalFishEvent = fishWeightEvents.find((fishEvent) => !fishEvent.toolsGroup);
+    const hasPreliminaryFish = fishWeightEvents.some(
+      (fishEvent) =>
+        !!fishEvent.toolsGroup &&
+        !!fishEvent.data &&
+        Object.values(fishEvent.data).some((amount) => Number(amount) > 0),
+    );
 
-    if (fishWeightEvents.length > 0 && !finalFishEvent) {
+    if (hasPreliminaryFish && !finalFishEvent) {
       throw new moleculer.Errors.ValidationError('Fish must be weighted');
     }
     const geom = coordinatesToGeometry(ctx.params.coordinates);


### PR DESCRIPTION
## Problem

User report: angler tries to end a fishing trip but is blocked with \"Sužvejotos žuvys turi būti pasvertos krante, prieš užbaigiant žvejybą\" — even though the \`/api/fishings/weights\` response shows \`preliminary: {}\` (no fish caught at all).

Reproduce:
1. Start fishing.
2. Set up tools, then check a tools group on the boat with no fish caught (\`data: {}\` or all zeroes).
3. Try \`POST /api/fishings/end\`.
4. Backend returns \`Fish must be weighted\`.

## Root cause

[\`endFishing\`](services/fishings.service.ts) validates:

\`\`\`ts
if (fishWeightEvents.length > 0 && !finalFishEvent) {
  throw new moleculer.Errors.ValidationError('Fish must be weighted');
}
\`\`\`

The check only looks at whether any weight events exist, not whether any of them recorded actual fish. Checking a tools group with zero catch still creates a per-toolsGroup \`weightEvent\` (with empty/zero \`data\`), which trips the guard even though there is nothing to weigh on shore.

## Fix

Replace the count-based check with a content-based one: only require an on-shore weighing if at least one preliminary weight event has any fish amount > 0. Empty/zero preliminary events no longer block ending.

\`\`\`ts
const hasPreliminaryFish = fishWeightEvents.some(
  (fishEvent) =>
    !!fishEvent.toolsGroup &&
    !!fishEvent.data &&
    Object.values(fishEvent.data).some((amount) => Number(amount) > 0),
);

if (hasPreliminaryFish && !finalFishEvent) {
  throw new moleculer.Errors.ValidationError('Fish must be weighted');
}
\`\`\`

Behavior preserved: a trip with any actual preliminary catch still requires the on-shore total before ending.

## Test plan

- [ ] No weight events at all → ending allowed (unchanged)
- [ ] Preliminary event with \`data: {}\` only → ending allowed (was blocked, now fixed)
- [ ] Preliminary event with \`data: { 1: 0, 2: 0 }\` only → ending allowed (was blocked, now fixed)
- [ ] Preliminary event with \`data: { 1: 1.5 }\` and no on-shore total → still blocked (regression guard)
- [ ] Preliminary event with fish + on-shore total weight event → ending allowed (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)