### PR TITLE
fix: alter fishTypes.priority to bigint

### DIFF
--- a/database/migrations/20260430154953_fishTypesPriorityBigint.js
+++ b/database/migrations/20260430154953_fishTypesPriorityBigint.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  await knex.schema.alterTable('fishTypes', (table) => {
+    table.bigInteger('priority').alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  await knex.schema.alterTable('fishTypes', (table) => {
+    table.integer('priority').alter();
+  });
+};


### PR DESCRIPTION
## Summary
- Seed values in \`services/fishTypes.service.ts\` go up to \`99999999999\` (~1e11), but \`20240108141655_fishTypesPriority.js\` created the column as int4 (max ~2.1e9).
- On prod the \`fishTypes\` table was empty, so \`seedDB()\` ran and threw \`value "99999999999" is out of range for type integer\` (PG 22003), crashing broker.start() and putting the API container in a restart loop.
- Staging was unaffected because the table already had data and \`seedDB\` skipped.

## Fix
New migration alters \`fishTypes.priority\` to \`bigint\`. Down migration restores int4 (only safe if existing data fits).

## Test plan
- [ ] Apply manually on prod first as hot-fix: \`ALTER TABLE "fishTypes" ALTER COLUMN priority TYPE bigint;\`
- [ ] Verify container starts: \`docker logs -f biip-production-zvejyba-api-1\` should reach \`API Gateway listening\`
- [ ] After merge + tag, deploy carries the migration so other envs are consistent
- [ ] Sanity: \`GET /zvejyba/api/public/fishTypes\` returns rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)