### PR TITLE
fix: end fishings cron now actually fires + close stale open sessions

### DIFF
--- a/database/migrations/20260502074247_closeStaleOpenFishings.js
+++ b/database/migrations/20260502074247_closeStaleOpenFishings.js
@@ -1,0 +1,67 @@
+/**
+ * One-shot data fix: close every fishing that was started on a previous
+ * Europe/Vilnius day and never received an END event. Caused by the
+ * `endFishings` cron not firing — the `Cron` mixin was missing on the
+ * fishings service. Pairs with the cron-mixin fix in the same PR.
+ *
+ * Some legacy rows have NULL start_event_id (likely from very old
+ * data — observed on staging: ids 296, 310, 317, 332, 339). For those
+ * we fall back to fishings.tenant_id / user_id and let END.geom be NULL.
+ *
+ * Idempotent: filtered by end_event_id IS NULL, so re-running is a no-op.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  await knex.raw(`
+    DO $$
+    DECLARE
+      f RECORD;
+      end_ts TIMESTAMPTZ;
+      new_event_id INT;
+    BEGIN
+      FOR f IN
+        SELECT
+          fi.id,
+          COALESCE(se.tenant_id, fi.tenant_id) AS tenant_id,
+          COALESCE(se.user_id, fi.user_id)     AS user_id,
+          COALESCE(se.geom, fi.geom)           AS geom,
+          fi.created_at
+        FROM fishings fi
+        LEFT JOIN fishing_events se ON se.id = fi.start_event_id
+        WHERE fi.end_event_id IS NULL
+          AND fi.deleted_at IS NULL
+          AND (fi.created_at AT TIME ZONE 'Europe/Vilnius')
+              < date_trunc('day', now() AT TIME ZONE 'Europe/Vilnius')
+        ORDER BY fi.id
+      LOOP
+        end_ts := ((date_trunc('day', f.created_at AT TIME ZONE 'Europe/Vilnius')
+                    + interval '1 day' - interval '1 second')
+                    AT TIME ZONE 'Europe/Vilnius');
+
+        INSERT INTO fishing_events
+          (type, tenant_id, user_id, geom, created_at, created_by)
+        VALUES
+          ('END', f.tenant_id, f.user_id, f.geom, end_ts, f.user_id)
+        RETURNING id INTO new_event_id;
+
+        UPDATE fishings
+        SET end_event_id = new_event_id,
+            updated_at   = end_ts,
+            updated_by   = f.user_id
+        WHERE id = f.id;
+      END LOOP;
+    END
+    $$;
+  `);
+};
+
+/**
+ * No-op down: undoing a one-shot data fix would re-open finalized fishings
+ * and orphan the END events we just created — not desirable.
+ *
+ * @param { import("knex").Knex } _knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (_knex) {};

--- a/mixins/profile.mixin.ts
+++ b/mixins/profile.mixin.ts
@@ -30,13 +30,19 @@ export default {
       return ctx;
     },
     beforeCreate(ctx: Context<any, UserAuthMeta>) {
+      // Vidiniai service-to-service call'ai (pvz., cron tick'as) gali kviesti
+      // be auth meta — tokiu atveju paliekam params nepakeistus, kad caller
+      // pats nuspręstų tenant/user reikšmes (žr. fishings.endFishings).
+      if (!ctx.meta?.authUser) {
+        return ctx;
+      }
       if (
         ![AuthUserRole.ADMIN, AuthUserRole.SUPER_ADMIN].some(
           (role) => role === ctx.meta.authUser.type,
         )
       ) {
         const profile = ctx.meta.profile;
-        const userId = ctx.meta.user.id;
+        const userId = ctx.meta.user?.id;
         ctx.params.tenant = profile || null;
         ctx.params.user = userId;
       }

--- a/services/fishings.service.ts
+++ b/services/fishings.service.ts
@@ -18,7 +18,7 @@ import {
 
 import ProfileMixin from '../mixins/profile.mixin';
 import { coordinatesToGeometry, geomToWgs } from '../modules/geometry';
-import { UserAuthMeta } from './api.service';
+import { AuthUserRole, UserAuthMeta } from './api.service';
 import { FishingEvent, FishingEventType } from './fishingEvents.service';
 import { FishType } from './fishTypes.service';
 import { Coordinates, CoordinatesProp, Location } from './location.service';
@@ -26,6 +26,8 @@ import { Polder } from './polders.service';
 import { Tenant } from './tenants.service';
 import { User } from './users.service';
 import { GetFishByFishingResponse, WeightEvent } from './weightEvents.service';
+
+const Cron = require('@r2d2bzh/moleculer-cron');
 
 export enum FishingType {
   ESTUARY = 'ESTUARY',
@@ -88,6 +90,7 @@ export type Fishing<
       srid: 3346,
     }),
     ProfileMixin,
+    Cron,
   ],
   crons: [
     {
@@ -271,15 +274,31 @@ export default class FishTypesService extends moleculer.Service {
     const result = [];
 
     for (const fishing of fishings) {
-      const endEvent: FishingEvent = await ctx.call('fishingEvents.create', {
-        geom: fishing.geom,
-        type: FishingEventType.END,
-      });
+      // Cron tick'as ateina be auth meta — perduodam fishing'o user/tenant,
+      // kad ProfileMixin.beforeCreate korektiškai užstamp'intų END event'ą.
+      const meta = {
+        user: { id: fishing.user } as User,
+        profile: fishing.tenant,
+        authUser: { type: AuthUserRole.USER },
+      };
 
-      const updatedFishing = await ctx.call('fishings.update', {
-        id: fishing.id,
-        endEvent: endEvent.id,
-      });
+      const endEvent: FishingEvent = await ctx.call(
+        'fishingEvents.create',
+        {
+          geom: fishing.geom,
+          type: FishingEventType.END,
+        },
+        { meta },
+      );
+
+      const updatedFishing = await ctx.call(
+        'fishings.update',
+        {
+          id: fishing.id,
+          endEvent: endEvent.id,
+        },
+        { meta },
+      );
 
       result.push(updatedFishing);
     }


### PR DESCRIPTION
## Summary
- **Bug:** žvejybų auto-uždarymas vidurnaktį (Europe/Vilnius) buvo parašytas (`fishings.service.ts:92` `crons:` blokas su `endFishings`), bet **niekada nevyko** — `@r2d2bzh/moleculer-cron` mixin'as buvo įdėtas tik `fishTypes.service.ts`, todėl `fishings` `crons:` blokas tyliai ignoruotas. Vakar (2026-05-01) keli žvejai paliko sesijas atviras, šįryt nebegali pradėti naujos.
- **Fix:**
  1. Pridėtas `Cron` mixin'as į `fishings.service.ts`.
  2. `endFishings` per kiekvieną žvejybą perduoda `meta = { user, profile, authUser }`, kad sukuriamas END event'as gautų teisingą `tenant`/`user` (kaip START event'as).
  3. `ProfileMixin.beforeCreate` apsaugotas nuo missing `ctx.meta.authUser` — defense in depth ateities vidiniams service-to-service call'ams.
- **Data fix:** `20260502074247_closeStaleOpenFishings.js` — vienkartinė migracija, kuri uždaro visas žvejybas su `end_event_id IS NULL`, pradėtas anksčiau nei einamosios dienos vidurnaktis (Europe/Vilnius). END event'as gauna `created_at = startDay 23:59:59 Europe/Vilnius`. Idempotentinė (filtruoja `end_event_id IS NULL`), `down()` no-op (re-open'inti uždarytas žvejybas ir orphan'inti END event'us nėra prasmės).

## Affected rows on prod (matytos `arūnui` šįryt)

| fishings.id | user | started |
|---|---|---|
| 19 | 365 | 2026-05-01 08:07 |
| 25 | 366 | 2026-05-01 10:04 |
| 32 | 368 | 2026-05-01 19:58 |
| 33 | 375 | 2026-05-01 21:18 (POLDERS) |

(`id=37` startuota 2026-05-02 08:05 — einama diena, NEBUS uždaryta.)

## Test plan
- [ ] Lokaliai `yarn dev` paleidžia migraciją be klaidų.
- [ ] REPL: `mol $ call fishings.endFishings` neberodo `Cannot read properties of undefined`.
- [ ] Staging deploy'as paleidžia migraciją; `SELECT count(*) FROM fishings WHERE end_event_id IS NULL AND deleted_at IS NULL AND created_at::date < CURRENT_DATE` lygu 0.
- [ ] Patikrinti, kad rytoj 00:00 cron'as nukrito (`fishings.endFishings` log entry arba metric).

🤖 Generated with [Claude Code](https://claude.com/claude-code)