### PR TITLE
refactor: system actor (Sistema) for auto-ended fishings + backfill

### DIFF
--- a/database/migrations/20260502091450_backfillSystemActorOnAutoEnds.js
+++ b/database/migrations/20260502091450_backfillSystemActorOnAutoEnds.js
@@ -1,0 +1,57 @@
+/**
+ * Pora prie ankstesnio fix'o (PR #110): tas migravimas sukūrė END
+ * event'us kaip „suklastotas vartotojas" — `user_id` ir `created_by`
+ * buvo užkrauti realių vartotojų ID, nors veiksmą padarė sistema.
+ *
+ * Šis backfill'as randa tas pačias eilutes pagal jų signature
+ * (type=END, deleted_at IS NULL, created_at exact match į
+ * `start_day 23:59:59 Europe/Vilnius` be jokios fracinės sekundės dalies —
+ * realūs vartotojo END'ai turi mikrosekundžių, mūsų sintetiniai ne) ir nuvalo:
+ *   fishing_events.user_id  → NULL
+ *   fishing_events.created_by → NULL
+ *   fishings.updated_by    → NULL  (taip pat užkrautas to paties)
+ *
+ * Idempotentinė: pakartotinai paleidus, atitinkamos eilutės jau yra
+ * NULL ir UPDATE'as no-op'ina. tenant_id sąmoningai paliekam — sistema
+ * vis tiek elgiasi tenant'o kontekste.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  await knex.raw(`
+    WITH targets AS (
+      SELECT fe.id AS event_id, f.id AS fishing_id
+      FROM fishing_events fe
+      JOIN fishings f ON f.end_event_id = fe.id
+      WHERE fe.type = 'END'
+        AND fe.deleted_at IS NULL
+        AND date_trunc('second', fe.created_at) = fe.created_at
+        AND fe.created_at = (
+          (date_trunc('day', f.created_at AT TIME ZONE 'Europe/Vilnius')
+            + interval '1 day' - interval '1 second')
+          AT TIME ZONE 'Europe/Vilnius'
+        )
+    ),
+    upd_events AS (
+      UPDATE fishing_events
+      SET user_id = NULL, created_by = NULL
+      FROM targets
+      WHERE fishing_events.id = targets.event_id
+      RETURNING fishing_events.id
+    )
+    UPDATE fishings
+    SET updated_by = NULL
+    FROM targets
+    WHERE fishings.id = targets.fishing_id;
+  `);
+};
+
+/**
+ * No-op down — atstatyti suklastotą user_id į konkrečius vartotojus
+ * neturim iš ko.
+ *
+ * @param { import("knex").Knex } _knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (_knex) {};

--- a/services/fishingEvents.service.ts
+++ b/services/fishingEvents.service.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import moleculer from 'moleculer';
+import moleculer, { Context } from 'moleculer';
 import { Service } from 'moleculer-decorators';
 import PostgisMixin from 'moleculer-postgis';
 import DbConnection from '../mixins/database.mixin';
@@ -82,11 +82,21 @@ export type FishingEvent<
         type: 'number',
         columnType: 'integer',
         columnName: 'userId',
-        populate: {
-          action: 'users.resolve',
-          params: {
-            scope: false,
-          },
+        // NULL user_id reiškia, kad event'ą sukūrė sistema (pvz., midnight
+        // cron'as uždarinėjantis nepataikytas žvejybas) — populate grąžina
+        // sintetinį Sistema actor'ą, kad UI galėtų atskirti nuo realaus
+        // vartotojo be magic id reikšmės.
+        async populate(ctx: Context, values: Array<number | null>) {
+          const realIds = Array.from(new Set(values.filter((v): v is number => v != null)));
+          const users: User[] = realIds.length
+            ? await ctx.call('users.resolve', { id: realIds, scope: false })
+            : [];
+          const byId = new Map(users.map((u) => [u.id, u]));
+          return values.map((v) =>
+            v == null
+              ? { id: null, firstName: 'Sistema', lastName: '', isSystem: true }
+              : byId.get(v),
+          );
         },
       },
       ...COMMON_FIELDS,

--- a/services/fishings.service.ts
+++ b/services/fishings.service.ts
@@ -18,7 +18,7 @@ import {
 
 import ProfileMixin from '../mixins/profile.mixin';
 import { coordinatesToGeometry, geomToWgs } from '../modules/geometry';
-import { AuthUserRole, UserAuthMeta } from './api.service';
+import { UserAuthMeta } from './api.service';
 import { FishingEvent, FishingEventType } from './fishingEvents.service';
 import { FishType } from './fishTypes.service';
 import { Coordinates, CoordinatesProp, Location } from './location.service';
@@ -274,31 +274,22 @@ export default class FishTypesService extends moleculer.Service {
     const result = [];
 
     for (const fishing of fishings) {
-      // Cron tick'as ateina be auth meta — perduodam fishing'o user/tenant,
-      // kad ProfileMixin.beforeCreate korektiškai užstamp'intų END event'ą.
-      const meta = {
-        user: { id: fishing.user } as User,
-        profile: fishing.tenant,
-        authUser: { type: AuthUserRole.USER },
-      };
+      // Sistema (cron) — ne pats vartotojas — uždaro žvejybą. user_id
+      // ir created_by lieka NULL: audit trail neigia neegzistuojantį
+      // „vartotojas baigė 23:59:59" veiksmą; populate'as parodys
+      // Sistema actor'ą. tenant'as išlaikomas, kad event'as liktų to
+      // paties tenant'o scope'e.
+      const endEvent: FishingEvent = await ctx.call('fishingEvents.create', {
+        geom: fishing.geom,
+        type: FishingEventType.END,
+        tenant: fishing.tenant ?? null,
+        user: null,
+      });
 
-      const endEvent: FishingEvent = await ctx.call(
-        'fishingEvents.create',
-        {
-          geom: fishing.geom,
-          type: FishingEventType.END,
-        },
-        { meta },
-      );
-
-      const updatedFishing = await ctx.call(
-        'fishings.update',
-        {
-          id: fishing.id,
-          endEvent: endEvent.id,
-        },
-        { meta },
-      );
+      const updatedFishing = await ctx.call('fishings.update', {
+        id: fishing.id,
+        endEvent: endEvent.id,
+      });
 
       result.push(updatedFishing);
     }


### PR DESCRIPTION
## Summary

Pora prie [PR #110](https://github.com/AplinkosMinisterija/biip-zvejyba-api/pull/110). Lukas pastebėjo, kad mano pirmoji versija „melavo" audit trail'ui — sistema'ti uždaromuose END event'uose user_id buvo užkrautas realių vartotojų. Dabar pataisyta:

### Code change (`refactor:` commit)
- **`fishings.endFishings`**: nebepasiunčiame meta su suklastotu user'iu. END event params'uose explicit `tenant: fishing.tenant, user: null`. ProfileMixin guard (PR #110) leidžia null praeiti, COMMON_FIELDS `createdBy.onCreate` jau gauna `undefined` → DB NULL.
- **`fishingEvents.user` populate**: kai `user_id IS NULL`, grąžina sintetinį actor'ą `{ id: null, firstName: 'Sistema', lastName: '', isSystem: true }`. Be magic int — `id` lieka `null`, `isSystem` flag'as paaiškina.

### Backfill migration (`chore(db):` commit)
- `20260502091450_backfillSystemActorOnAutoEnds.js` randa visus auto-end event'us pagal jų signature (type=END, `created_at = startDay 23:59:59 Europe/Vilnius` be fracinių sekundžių) ir nuvalo `user_id`/`created_by`/`updated_by` į NULL. `tenant_id` paliekam.
- Idempotentinis (re-run no-op'ina), down no-op.
- Saugu nuo false positives: realūs vartotojo END events visada turi mikrosekundes — filtras juos atmeta.

## Staging dry-run rezultatai

```
BEFORE_targets:    14    (atitinka 14 stale fishings iš PR #110 migracijos)
After UPDATE:       0    impersonated rows liko
Sample (id 675):   user_id=NULL, created_by=NULL, tenant_id=62 (preserved)
Linked fishing 296: updated_by=NULL
Natural ENDs su user_id (53 viso, su .856/.981 ir pan.):  NEpaliesti
```

## Test plan
- [ ] Lokaliai `yarn dev` paleidžia migraciją be klaidų
- [ ] REPL: `mol $ call fishings.endFishings` su nauja open žvejyba sukuria END su `user_id=NULL, created_by=NULL`
- [ ] HTTP: `GET /fishingEvents/<id>?populate=user` grąžina `{id:null, firstName:'Sistema', isSystem:true}` sistem'iniam event'ui ir realų user'į natūraliam
- [ ] Staging deploy → patikrinti, kad mano dry-run'o numatyti 14 eilučių iš tikrųjų atnaujinti
- [ ] Prod release: 4 eilutės (id 19/25/32/33 atitinkantys event'ai 67/68/69/70) pataisyti

## Related
- Pirminis fix: #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)