### PR TITLE
fix(fishings): scope active fishing by user, not just tenant

### DIFF
--- a/services/fishings.service.ts
+++ b/services/fishings.service.ts
@@ -206,7 +206,9 @@ export type Fishing<
 
           const polderIds = Array.from(
             new Set(
-              fishings.filter((fishing) => !!fishing.polderId).map((fishing: any) => fishing.polderId),
+              fishings
+                .filter((fishing) => !!fishing.polderId)
+                .map((fishing: any) => fishing.polderId),
             ),
           );
           const polders: Polder[] = polderIds.length
@@ -418,10 +420,6 @@ export default class FishTypesService extends moleculer.Service {
     auth: RestrictionType.USER,
   })
   async currentFishing(ctx: Context<any, UserAuthMeta>) {
-    // Aktyvi žvejyba yra individuali — to paties tenant'o nariai NEsidalina
-    // viena sesija. ProfileMixin.beforeSelect prideda tik tenant filtrą,
-    // todėl čia papildomai apribojame pagal user'į iš meta. List/find tyčia
-    // paliekama tenant platumo — bendradarbiai mato vieni kitų istoriją.
     const userQuery = ctx.meta?.user?.id ? { user: ctx.meta.user.id } : {};
     return await ctx.call('fishings.findOne', {
       query: {

--- a/services/fishings.service.ts
+++ b/services/fishings.service.ts
@@ -2,7 +2,7 @@
 
 import ExcelJS from 'exceljs';
 import moleculer, { Context } from 'moleculer';
-import { Action, Service } from 'moleculer-decorators';
+import { Action, Method, Service } from 'moleculer-decorators';
 import PostgisMixin from 'moleculer-postgis';
 import DbConnection from '../mixins/database.mixin';
 import {
@@ -18,7 +18,7 @@ import {
 
 import ProfileMixin from '../mixins/profile.mixin';
 import { coordinatesToGeometry, geomToWgs } from '../modules/geometry';
-import { UserAuthMeta } from './api.service';
+import { AuthUserRole, UserAuthMeta } from './api.service';
 import { FishingEvent, FishingEventType } from './fishingEvents.service';
 import { FishType } from './fishTypes.service';
 import { Coordinates, CoordinatesProp, Location } from './location.service';
@@ -749,5 +749,36 @@ export default class FishTypesService extends moleculer.Service {
       user: fishing.user,
       history: events.sort((a, b) => a.date.getTime() - b.date.getTime()),
     };
+  }
+
+  // Fishings yra individualios — to paties tenant'o nariai NEsidalina aktyvia
+  // žvejyba. ProfileMixin numatytai filtruoja tik pagal tenant'ą, todėl be
+  // šio override'o `currentFishing` būtų grąžinusi bet kurio tenant'o nario
+  // atvirą sesiją (ir `endFishing` būtų uždaręs svetimą).
+  @Method
+  async beforeSelect(ctx: Context<any, UserAuthMeta>) {
+    if (ctx.meta) {
+      const isAdmin = [AuthUserRole.SUPER_ADMIN, AuthUserRole.ADMIN].some(
+        (r) => r === ctx.meta?.authUser?.type,
+      );
+      if (!isAdmin) {
+        const q = ctx.params.query;
+        if (ctx.meta.profile && ctx.meta?.user) {
+          ctx.params.query = {
+            tenant: ctx.meta.profile,
+            user: ctx.meta.user.id,
+            ...q,
+          };
+        } else if (!ctx.meta.profile && ctx.meta.user) {
+          ctx.params.query = {
+            user: ctx.meta.user.id,
+            tenant: { $exists: false },
+            ...q,
+          };
+        }
+      }
+    }
+    ctx.params.sort = ctx.params.sort || '-createdAt';
+    return ctx;
   }
 }

--- a/services/fishings.service.ts
+++ b/services/fishings.service.ts
@@ -2,7 +2,7 @@
 
 import ExcelJS from 'exceljs';
 import moleculer, { Context } from 'moleculer';
-import { Action, Method, Service } from 'moleculer-decorators';
+import { Action, Service } from 'moleculer-decorators';
 import PostgisMixin from 'moleculer-postgis';
 import DbConnection from '../mixins/database.mixin';
 import {
@@ -18,7 +18,7 @@ import {
 
 import ProfileMixin from '../mixins/profile.mixin';
 import { coordinatesToGeometry, geomToWgs } from '../modules/geometry';
-import { AuthUserRole, UserAuthMeta } from './api.service';
+import { UserAuthMeta } from './api.service';
 import { FishingEvent, FishingEventType } from './fishingEvents.service';
 import { FishType } from './fishTypes.service';
 import { Coordinates, CoordinatesProp, Location } from './location.service';
@@ -418,10 +418,15 @@ export default class FishTypesService extends moleculer.Service {
     auth: RestrictionType.USER,
   })
   async currentFishing(ctx: Context<any, UserAuthMeta>) {
-    //Users in the same tenant do not share fishing. Each person should start and finish his/her own fishing.
+    // Aktyvi žvejyba yra individuali — to paties tenant'o nariai NEsidalina
+    // viena sesija. ProfileMixin.beforeSelect prideda tik tenant filtrą,
+    // todėl čia papildomai apribojame pagal user'į iš meta. List/find tyčia
+    // paliekama tenant platumo — bendradarbiai mato vieni kitų istoriją.
+    const userQuery = ctx.meta?.user?.id ? { user: ctx.meta.user.id } : {};
     return await ctx.call('fishings.findOne', {
       query: {
         ...ctx.params.query,
+        ...userQuery,
         startEvent: { $exists: true },
         endEvent: { $exists: false },
       },
@@ -749,36 +754,5 @@ export default class FishTypesService extends moleculer.Service {
       user: fishing.user,
       history: events.sort((a, b) => a.date.getTime() - b.date.getTime()),
     };
-  }
-
-  // Fishings yra individualios — to paties tenant'o nariai NEsidalina aktyvia
-  // žvejyba. ProfileMixin numatytai filtruoja tik pagal tenant'ą, todėl be
-  // šio override'o `currentFishing` būtų grąžinusi bet kurio tenant'o nario
-  // atvirą sesiją (ir `endFishing` būtų uždaręs svetimą).
-  @Method
-  async beforeSelect(ctx: Context<any, UserAuthMeta>) {
-    if (ctx.meta) {
-      const isAdmin = [AuthUserRole.SUPER_ADMIN, AuthUserRole.ADMIN].some(
-        (r) => r === ctx.meta?.authUser?.type,
-      );
-      if (!isAdmin) {
-        const q = ctx.params.query;
-        if (ctx.meta.profile && ctx.meta?.user) {
-          ctx.params.query = {
-            tenant: ctx.meta.profile,
-            user: ctx.meta.user.id,
-            ...q,
-          };
-        } else if (!ctx.meta.profile && ctx.meta.user) {
-          ctx.params.query = {
-            user: ctx.meta.user.id,
-            tenant: { $exists: false },
-            ...q,
-          };
-        }
-      }
-    }
-    ctx.params.sort = ctx.params.sort || '-createdAt';
-    return ctx;
   }
 }


### PR DESCRIPTION
## Summary
- Tenant-mate fishermen were sharing the same active fishing session: a non-admin's `GET /zvejyba/api/fishings/current` returned any open session in the tenant, and `POST /end` would then close someone else's session.
- Root cause: [`ProfileMixin.beforeSelect`](mixins/profile.mixin.ts#L13-L18) narrows tenant-profile queries by `tenant` only, never by `user`. `currentFishing` inherits that filter and so does every action that validates via it.
- Fix: inside [`fishings.currentFishing`](services/fishings.service.ts#L420), additionally restrict the `findOne` query to `user: ctx.meta.user.id`. List/find/get/count are intentionally **left tenant-wide** so tenant members can still review each other's fishing history.

This automatically fixes downstream calls that go through `currentFishing`: `POST /start` validation, `POST /end`, `POST /skip`, `GET /weights`, and `weightEvents.beforeFishWeigh`. Admin/super-admin queries are unaffected.

## Test plan
- [ ] Two users in the same tenant: A starts a fishing → B's `GET /current` returns null (was returning A's row).
- [ ] B can `POST /start` while A is fishing (instead of being told "Fishing already started").
- [ ] B's `POST /end` no longer closes A's session.
- [ ] B can still `GET /fishings` and see A's history (tenant-wide list preserved).
- [ ] `GET /history/:id` of A's fishing still resolves for B inside the same tenant.
- [ ] User in personal profile (no tenant) still sees only their own fishings.
- [ ] Admin/super-admin can still `GET /fishings` across the whole tenant.
- [ ] `GET /exportCaughtFishes` still works for admins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)