### PR TITLE
fix(auth): don't wipe tenant fields with empty values from e-vartai

### DIFF
--- a/services/auth.service.ts
+++ b/services/auth.service.ts
@@ -164,13 +164,16 @@ export default class AuthService extends moleculer.Service {
         continue;
       }
 
-      await ctx.call('tenants.update', {
-        id: tenant.id,
-        name: authGroup.name,
-        code: authGroup.companyCode,
-        email: authGroup.companyEmail,
-        phone: authGroup.companyPhone,
-      });
+      // Only forward fields that E-vartai actually returned. Fizinis-asmuo
+      // logins on behalf of a company sometimes ship an empty `companyName`,
+      // which would otherwise wipe the locally imported tenant name.
+      const tenantUpdate: Record<string, any> = { id: tenant.id };
+      if (authGroup.name) tenantUpdate.name = authGroup.name;
+      if (authGroup.companyCode) tenantUpdate.code = authGroup.companyCode;
+      if (authGroup.companyEmail) tenantUpdate.email = authGroup.companyEmail;
+      if (authGroup.companyPhone) tenantUpdate.phone = authGroup.companyPhone;
+
+      await ctx.call('tenants.update', tenantUpdate);
 
       const tenantUser: TenantUser = await ctx.call('tenantUsers.findOne', {
         query: {


### PR DESCRIPTION
## Summary
- When a fizinis asmuo logged in representing a company, E-vartai sometimes returned an empty `companyName`. `afterUserLoggedIn` forwarded that into `tenants.update`, blanking the locally imported tenant name while `code` / `email` / `phone` stayed intact (they fall back to the user's personal contact info, so they're never empty — which matched the symptom report).
- Skip undefined/empty fields in the `tenants.update` payload so a missing `companyName` can no longer overwrite a good local value.

## Test plan
- [ ] Log in via E-vartai as fizinis asmuo on behalf of an imported tenant where the E-vartai ticket has no `companyName` → tenant name in DB is preserved.
- [ ] Log in via E-vartai (juridinis) where `companyName` is present → tenant row still gets the up-to-date name/email/phone.
- [ ] Existing `tenants.importBatch` flow unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)