### PR TITLE
feat(events): flag manual location for Kuršių marios events

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,35 @@ collide** (polder id 1 vs bar 1). `toolsGroupsByLocation` filters by
 by stored `location.type` (legacy rows have it null). Don't change this
 without re-thinking the legacy fallback.
 
+### Virtual-field populate gotchas
+
+When a service uses `secure: true` on its primary key (every service in
+this repo does for `id`), references to those rows are encoded on the
+way out — including in nested `ctx.call('…events.find', {…})` results
+*if* you ask for them via `fields: [...]`. Two things follow:
+
+1. **Don't combine `fields: ['<reference>']` with `secure` parents in a
+   populate aggregator.** The returned field becomes the encoded string,
+   not the raw integer FK, so `Number(r.fishing)` is `NaN` and any
+   `Set<number>` lookup silently misses every row.
+2. **Prefer a raw SQL query (`this.adapter.knex` or `this.rawQuery`) for
+   "does any related row match?" aggregations** — Mongo-DSL through
+   moleculer-db, secure ID coding, ProfileMixin scopes, and JSONB
+   selectors layer on top of each other in ways that are essentially
+   unreviewable.
+3. **Always assert the deployed endpoint's response after wiring a
+   virtual field.** `tsc --noEmit` and `yarn build` only verify the
+   types — they don't catch ID encoding mismatches, missing populate
+   path entries, or scope filters that wipe the result. Hit the route
+   with `curl | jq` (or DevTools Network) and look at the field
+   *before* claiming the populate works.
+
+Real incident (PR #117 follow-up): `Fishing.hasManualLocation` was
+implemented with `fields: ['fishing']` in the aggregator → every fishing
+came back `false` even though the same events had `locationManual=true`
+in `getHistory`. The detail page rendered the warning correctly but the
+journal list never did. Switched to raw SQL.
+
 ## Patterns when adding code
 
 - New entity: copy a small service (e.g. `polders.service.ts`), wire its
@@ -199,6 +228,12 @@ appear without the `call` prefix (e.g. `mol $ tenants-import --dry`).
 
 ## Recent fix log (worth knowing)
 
+- **PR #117** — `location_manual` boolean on `tools_groups_events` /
+  `weight_events` plus virtual `Fishing.hasManualLocation`. First cut
+  used `ctx.call('…events.find', { fields: ['fishing'] })` for the
+  aggregation and silently miscounted because of the `secure: true` ID
+  encoding (see "Virtual-field populate gotchas"). Final version uses a
+  raw SQL `UNION` against both event tables.
 - **PR #105** — E-vartai juridical login: propagate `{ meta: authToken }`
   to `tenantUsers.create` so director auto-creation actually works.
 - **PR #106** — polders feature: new `polders` table + service, fishings

--- a/database/migrations/20260513140000_addLocationManualFlag.js
+++ b/database/migrations/20260513140000_addLocationManualFlag.js
@@ -1,13 +1,14 @@
 /**
- * Žvejys gali pasirinkti įvykio lokaciją (Kuršių marių barą / polderio
- * vietą / vidaus vandens telkinį) GPS automatiškai arba rankiniu būdu,
- * jei nustatymas nepataikė. Šis flag'as `location_manual` skiriasi tarp
- * tų dviejų atvejų, kad admin pusėje galėtume parodyti šauktuko ikoną
- * (kol kas reikalavimas tik Kuršių marioms, bet kolumną pridedam viskam
- * kas turi `location` field'ą, kad nereikėtų vėliau papildyti).
+ * A fisher picks the event location (Kuršių marios bar / polder patch /
+ * inland water body) either via automatic GPS detection or via the
+ * manual picker when GPS missed. `location_manual` distinguishes those
+ * two paths so the admin UI can flag manual picks with a warning icon
+ * (current requirement is Kuršių marios only, but adding the column on
+ * every event type that carries `location` so we don't have to migrate
+ * again later).
  *
- * Default false — esamos eilutės laikomos automatiškai nustatytomis,
- * nes kitokios info istoriškai nėra.
+ * Default false — historical rows are treated as auto-detected because
+ * we have no other signal for them.
  *
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }

--- a/database/migrations/20260513140000_addLocationManualFlag.js
+++ b/database/migrations/20260513140000_addLocationManualFlag.js
@@ -1,0 +1,37 @@
+/**
+ * Žvejys gali pasirinkti įvykio lokaciją (Kuršių marių barą / polderio
+ * vietą / vidaus vandens telkinį) GPS automatiškai arba rankiniu būdu,
+ * jei nustatymas nepataikė. Šis flag'as `location_manual` skiriasi tarp
+ * tų dviejų atvejų, kad admin pusėje galėtume parodyti šauktuko ikoną
+ * (kol kas reikalavimas tik Kuršių marioms, bet kolumną pridedam viskam
+ * kas turi `location` field'ą, kad nereikėtų vėliau papildyti).
+ *
+ * Default false — esamos eilutės laikomos automatiškai nustatytomis,
+ * nes kitokios info istoriškai nėra.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema
+    .alterTable('toolsGroupsEvents', (table) => {
+      table.boolean('locationManual').notNullable().defaultTo(false);
+    })
+    .alterTable('weightEvents', (table) => {
+      table.boolean('locationManual').notNullable().defaultTo(false);
+    });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema
+    .alterTable('toolsGroupsEvents', (table) => {
+      table.dropColumn('locationManual');
+    })
+    .alterTable('weightEvents', (table) => {
+      table.dropColumn('locationManual');
+    });
+};

--- a/mixins/database.mixin.ts
+++ b/mixins/database.mixin.ts
@@ -158,10 +158,14 @@ export default function (opts: any = {}) {
 
         return ids.filter((id) => queryIds.indexOf(id) >= 0);
       },
-      async rawQuery(ctx: Context, sql: string) {
-        const adapter = await this.getAdapter(ctx);
+      async rawQuery(
+        ctx: Context,
+        sql: string,
+        bindings?: readonly any[],
+      ): Promise<any[]> {
+        const adapter = await (this as any).getAdapter(ctx);
         const knex = adapter.client;
-        const result = await knex.raw(sql);
+        const result = await knex.raw(sql, (bindings ?? []) as any[]);
         return result.rows;
       },
     },

--- a/services/fishings.service.ts
+++ b/services/fishings.service.ts
@@ -197,9 +197,9 @@ export type Fishing<
         readonly: true,
         virtual: true,
         async populate(ctx: any, _values: any, fishings: Fishing[]) {
-          // True jei bent vienas šios žvejybos event'as (toolsGroup arba
-          // weight) turėjo location_manual=true. Admin pusėje pagal tai
-          // rodom šauktuko ikoną žurnalo eilutėje (Kuršių marių žvejyboms).
+          // True if at least one event of this fishing (toolsGroup or
+          // weight) had location_manual=true. Admin uses this to render
+          // the warning icon on the journal row (Kuršių marios fishings).
           if (!fishings.length) return [];
           const fishingIds = fishings.map((f) => f.id);
           const [tgRows, weRows]: [Array<{ fishingId: number }>, Array<{ fishingId: number }>] =
@@ -215,8 +215,8 @@ export type Fishing<
             ]);
           const flagged = new Set<number>();
           for (const r of [...tgRows, ...weRows]) {
-            // moleculer'is grąžina su nepulinčiu raw field name — pasiimam
-            // bet kurį `fishing`-vardo lauką, kuris yra apsupęs id'us.
+            // moleculer can return the raw column name unmapped; accept
+            // either the camelCase `fishing` or the snake_case fallback.
             const id = (r as any).fishing ?? (r as any).fishingId;
             if (id != null) flagged.add(Number(id));
           }
@@ -535,6 +535,26 @@ export default class FishTypesService extends moleculer.Service {
     >,
   ) {
     const { data, preliminaryData } = ctx.params;
+
+    // Every fish the fisher registered on the boat (preliminary) must
+    // also appear in the onshore payload — the value can be 0 kg (if all
+    // were released back to the water), but the key has to be present.
+    // Prevents accidentally dropping e.g. undersized fish from the final
+    // catch report.
+    const missingKeys: FishType['id'][] = [];
+    for (const key in preliminaryData) {
+      const finalValue = data[key];
+      if (finalValue === undefined || finalValue === null) {
+        missingKeys.push(key as any);
+      }
+    }
+    if (missingKeys.length > 0) {
+      throw new moleculer.Errors.ValidationError(
+        'Missing onshore weight for fish caught on boat',
+        'MISSING_ONSHORE_WEIGHT',
+        { missingFishTypeIds: missingKeys },
+      );
+    }
 
     const invalidKeys: FishType['id'][] = [];
 

--- a/services/fishings.service.ts
+++ b/services/fishings.service.ts
@@ -52,6 +52,7 @@ type Event = {
   geom: any;
   coordinates?: Coordinates;
   location?: any;
+  locationManual?: boolean;
   data?: any;
 };
 
@@ -67,6 +68,7 @@ interface Fields extends CommonFields {
   tenant: Tenant['id'];
   user: User['id'];
   weightEvents: any;
+  hasManualLocation: boolean;
 }
 
 interface Populates extends CommonPopulates {
@@ -188,6 +190,37 @@ export type Fishing<
               return ctx.call('weightEvents.getFishByFishing', { fishingId: fishing.id });
             }),
           );
+        },
+      },
+      hasManualLocation: {
+        type: 'boolean',
+        readonly: true,
+        virtual: true,
+        async populate(ctx: any, _values: any, fishings: Fishing[]) {
+          // True jei bent vienas šios žvejybos event'as (toolsGroup arba
+          // weight) turėjo location_manual=true. Admin pusėje pagal tai
+          // rodom šauktuko ikoną žurnalo eilutėje (Kuršių marių žvejyboms).
+          if (!fishings.length) return [];
+          const fishingIds = fishings.map((f) => f.id);
+          const [tgRows, weRows]: [Array<{ fishingId: number }>, Array<{ fishingId: number }>] =
+            await Promise.all([
+              ctx.call('toolsGroupsEvents.find', {
+                query: { fishing: { $in: fishingIds }, locationManual: true },
+                fields: ['fishing'],
+              }),
+              ctx.call('weightEvents.find', {
+                query: { fishing: { $in: fishingIds }, locationManual: true },
+                fields: ['fishing'],
+              }),
+            ]);
+          const flagged = new Set<number>();
+          for (const r of [...tgRows, ...weRows]) {
+            // moleculer'is grąžina su nepulinčiu raw field name — pasiimam
+            // bet kurį `fishing`-vardo lauką, kuris yra apsupęs id'us.
+            const id = (r as any).fishing ?? (r as any).fishingId;
+            if (id != null) flagged.add(Number(id));
+          }
+          return fishings.map((f) => flagged.has(Number(f.id)));
         },
       },
       location: {
@@ -484,6 +517,7 @@ export default class FishTypesService extends moleculer.Service {
     auth: RestrictionType.USER,
     params: {
       coordinates: CoordinatesProp,
+      locationManual: { type: 'boolean', optional: true, convert: true },
       data: 'object',
       preliminaryData: 'object',
     },
@@ -493,6 +527,7 @@ export default class FishTypesService extends moleculer.Service {
       {
         coordinates: Coordinates;
         location: Location;
+        locationManual?: boolean;
         data: { [key: FishType['id']]: number };
         preliminaryData: { [key: FishType['id']]: number };
       },
@@ -520,9 +555,19 @@ export default class FishTypesService extends moleculer.Service {
       throw new moleculer.Errors.ValidationError('Weight difference greater than 20%');
     }
 
+    const currentFishing: Fishing = await ctx.call('fishings.currentFishing');
+    let locationManual = !!ctx.params.locationManual;
+    if (currentFishing?.type === FishingType.ESTUARY && ctx.params.location?.id) {
+      locationManual = await ctx.call('locations.isEstuaryLocationManual', {
+        locationId: String(ctx.params.location.id),
+        coordinates: ctx.params.coordinates,
+      });
+    }
+
     await ctx.call('weightEvents.createWeightEvent', {
       coordinates: ctx.params.coordinates,
       location: ctx.params.location,
+      locationManual,
       data,
     });
 
@@ -708,6 +753,7 @@ export default class FishTypesService extends moleculer.Service {
         geom: t.geom,
         coordinates,
         location: t.location,
+        locationManual: !!t.locationManual,
         date: t.createdAt,
         data: t.toolsGroup,
       });
@@ -729,6 +775,7 @@ export default class FishTypesService extends moleculer.Service {
         geom: w.geom,
         coordinates,
         location: w.location,
+        locationManual: !!w.locationManual,
         date: w.createdAt,
         data: { fish: w.data, toolsGroup: w.toolsGroup },
       });
@@ -740,6 +787,7 @@ export default class FishTypesService extends moleculer.Service {
         type: EventType.WEIGHT_ON_SHORE,
         geom: fishingWeights.fishOnShore.geom,
         coordinates,
+        locationManual: !!fishingWeights.fishOnShore.locationManual,
         date: fishingWeights.fishOnShore.createdAt,
         data: fishingWeights.fishOnShore.data,
       });

--- a/services/fishings.service.ts
+++ b/services/fishings.service.ts
@@ -592,17 +592,14 @@ export default class FishTypesService extends moleculer.Service {
   async getManualLocationFlags(ctx: Context<{ fishingIds: number[] }>): Promise<number[]> {
     const ids = (ctx.params.fishingIds || []).map(Number).filter(Number.isFinite);
     if (!ids.length) return [];
-    // `rawQuery` here doesn't support parameter binding (see
-    // `mixins/database.mixin.ts:161`), so we inline. Safe because every id
-    // already passed `Number.isFinite` — no string can sneak through.
-    const idList = ids.join(',');
     const rows: Array<{ fishing_id: number }> = await this.rawQuery(
       ctx,
       `SELECT DISTINCT fishing_id FROM tools_groups_events
-         WHERE fishing_id IN (${idList}) AND location_manual = TRUE AND deleted_at IS NULL
+         WHERE fishing_id = ANY(?) AND location_manual = TRUE AND deleted_at IS NULL
        UNION
        SELECT DISTINCT fishing_id FROM weight_events
-         WHERE fishing_id IN (${idList}) AND location_manual = TRUE AND deleted_at IS NULL`,
+         WHERE fishing_id = ANY(?) AND location_manual = TRUE AND deleted_at IS NULL`,
+      [ids, ids],
     );
     return rows.map((r) => Number(r.fishing_id)).filter(Number.isFinite);
   }

--- a/services/fishings.service.ts
+++ b/services/fishings.service.ts
@@ -555,19 +555,10 @@ export default class FishTypesService extends moleculer.Service {
       throw new moleculer.Errors.ValidationError('Weight difference greater than 20%');
     }
 
-    const currentFishing: Fishing = await ctx.call('fishings.currentFishing');
-    let locationManual = !!ctx.params.locationManual;
-    if (currentFishing?.type === FishingType.ESTUARY && ctx.params.location?.id) {
-      locationManual = await ctx.call('locations.isEstuaryLocationManual', {
-        locationId: String(ctx.params.location.id),
-        coordinates: ctx.params.coordinates,
-      });
-    }
-
     await ctx.call('weightEvents.createWeightEvent', {
       coordinates: ctx.params.coordinates,
       location: ctx.params.location,
-      locationManual,
+      locationManual: !!ctx.params.locationManual,
       data,
     });
 

--- a/services/fishings.service.ts
+++ b/services/fishings.service.ts
@@ -200,27 +200,20 @@ export type Fishing<
           // True if at least one event of this fishing (toolsGroup or
           // weight) had location_manual=true. Admin uses this to render
           // the warning icon on the journal row (Kuršių marios fishings).
+          //
+          // Delegate to a dedicated action so we can debug via REPL
+          // (`mol $ call fishings.getManualLocationFlags --fishingIds 321`)
+          // — the previous moleculer-db `find` + `fields: ['fishing']`
+          // approach silently dropped the FK because of `secure: true` ID
+          // encoding (see CLAUDE.md → "Virtual-field populate gotchas").
           if (!fishings.length) return [];
-          const fishingIds = fishings.map((f) => f.id);
-          const [tgRows, weRows]: [Array<{ fishingId: number }>, Array<{ fishingId: number }>] =
-            await Promise.all([
-              ctx.call('toolsGroupsEvents.find', {
-                query: { fishing: { $in: fishingIds }, locationManual: true },
-                fields: ['fishing'],
-              }),
-              ctx.call('weightEvents.find', {
-                query: { fishing: { $in: fishingIds }, locationManual: true },
-                fields: ['fishing'],
-              }),
-            ]);
-          const flagged = new Set<number>();
-          for (const r of [...tgRows, ...weRows]) {
-            // moleculer can return the raw column name unmapped; accept
-            // either the camelCase `fishing` or the snake_case fallback.
-            const id = (r as any).fishing ?? (r as any).fishingId;
-            if (id != null) flagged.add(Number(id));
-          }
-          return fishings.map((f) => flagged.has(Number(f.id)));
+          const ids = fishings.map((f) => Number(f.id)).filter(Number.isFinite);
+          if (!ids.length) return fishings.map(() => false);
+          const flagged: number[] = await ctx.call('fishings.getManualLocationFlags', {
+            fishingIds: ids,
+          });
+          const flaggedSet = new Set(flagged.map(Number));
+          return fishings.map((f) => flaggedSet.has(Number(f.id)));
         },
       },
       location: {
@@ -583,6 +576,35 @@ export default class FishTypesService extends moleculer.Service {
     });
 
     return { success: true };
+  }
+
+  // Internal helper for the `hasManualLocation` virtual field on Fishing.
+  // Returns the subset of `fishingIds` that have at least one event with
+  // `location_manual = true`. Raw SQL avoids the moleculer-db DSL + secure
+  // ID + ProfileMixin scope layering that silently miscounted the first
+  // version of this aggregation (see CLAUDE.md → "Virtual-field populate
+  // gotchas"). No `rest` — internal-only.
+  @Action({
+    params: {
+      fishingIds: { type: 'array', items: 'number|convert', min: 1 },
+    },
+  })
+  async getManualLocationFlags(ctx: Context<{ fishingIds: number[] }>): Promise<number[]> {
+    const ids = (ctx.params.fishingIds || []).map(Number).filter(Number.isFinite);
+    if (!ids.length) return [];
+    // `rawQuery` here doesn't support parameter binding (see
+    // `mixins/database.mixin.ts:161`), so we inline. Safe because every id
+    // already passed `Number.isFinite` — no string can sneak through.
+    const idList = ids.join(',');
+    const rows: Array<{ fishing_id: number }> = await this.rawQuery(
+      ctx,
+      `SELECT DISTINCT fishing_id FROM tools_groups_events
+         WHERE fishing_id IN (${idList}) AND location_manual = TRUE AND deleted_at IS NULL
+       UNION
+       SELECT DISTINCT fishing_id FROM weight_events
+         WHERE fishing_id IN (${idList}) AND location_manual = TRUE AND deleted_at IS NULL`,
+    );
+    return rows.map((r) => Number(r.fishing_id)).filter(Number.isFinite);
   }
 
   @Action({

--- a/services/location.service.ts
+++ b/services/location.service.ts
@@ -178,6 +178,44 @@ export default class LocationsService extends moleculer.Service {
     };
   }
 
+  /**
+   * Server-side derivacija ar Kuršių marių event'as buvo užregistruotas su
+   * rankiniu būdu pasirinkta lokacija (bar'u). Klientas-mobile manual atveju
+   * siunčia coordinates = bar centroid (iš `getFishingSections`), o GPS atveju —
+   * faktines telefono koordinates baro poligone. Lyginam su centroid'u (su
+   * tolerancija ~5 m) ir grąžinam true jei tiksliai sutampa.
+   *
+   * Tikslas: net jei klientas išjungia / suklastoja `locationManual` flag'ą,
+   * server'is gali nepriklausomai pamatyti, kad event'as registruotas su bar
+   * centroid'u, ne faktine GPS pozicija.
+   */
+  @Action({
+    params: {
+      locationId: 'string',
+      coordinates: CoordinatesProp,
+    },
+  })
+  async isEstuaryLocationManual(
+    ctx: Context<{ locationId: string; coordinates: Coordinates }>,
+  ): Promise<boolean> {
+    if (!ctx.params.locationId || !ctx.params.coordinates) return false;
+    try {
+      const sections: Array<{ id: string; x: number; y: number }> = await ctx.call(
+        'locations.getFishingSections',
+      );
+      const bar = sections?.find((s) => String(s.id) === String(ctx.params.locationId));
+      if (!bar || typeof bar.x !== 'number' || typeof bar.y !== 'number') return false;
+      const dx = bar.x - ctx.params.coordinates.x;
+      const dy = bar.y - ctx.params.coordinates.y;
+      const distanceMeters = Math.sqrt(dx * dx + dy * dy); // LKS-94 (EPSG:3346) units are meters
+      return distanceMeters < 5;
+    } catch {
+      // Jei QGIS nepasiekiamas, nepriimam sprendimo — leidžiam client'o flag'ui
+      // įtaką (caller'is sprendžia kaip elgtis su `false` rezultatu).
+      return false;
+    }
+  }
+
   @Action({
     rest: 'GET /fishing_sections',
     cache: {

--- a/services/location.service.ts
+++ b/services/location.service.ts
@@ -178,44 +178,6 @@ export default class LocationsService extends moleculer.Service {
     };
   }
 
-  /**
-   * Server-side derivacija ar Kuršių marių event'as buvo užregistruotas su
-   * rankiniu būdu pasirinkta lokacija (bar'u). Klientas-mobile manual atveju
-   * siunčia coordinates = bar centroid (iš `getFishingSections`), o GPS atveju —
-   * faktines telefono koordinates baro poligone. Lyginam su centroid'u (su
-   * tolerancija ~5 m) ir grąžinam true jei tiksliai sutampa.
-   *
-   * Tikslas: net jei klientas išjungia / suklastoja `locationManual` flag'ą,
-   * server'is gali nepriklausomai pamatyti, kad event'as registruotas su bar
-   * centroid'u, ne faktine GPS pozicija.
-   */
-  @Action({
-    params: {
-      locationId: 'string',
-      coordinates: CoordinatesProp,
-    },
-  })
-  async isEstuaryLocationManual(
-    ctx: Context<{ locationId: string; coordinates: Coordinates }>,
-  ): Promise<boolean> {
-    if (!ctx.params.locationId || !ctx.params.coordinates) return false;
-    try {
-      const sections: Array<{ id: string; x: number; y: number }> = await ctx.call(
-        'locations.getFishingSections',
-      );
-      const bar = sections?.find((s) => String(s.id) === String(ctx.params.locationId));
-      if (!bar || typeof bar.x !== 'number' || typeof bar.y !== 'number') return false;
-      const dx = bar.x - ctx.params.coordinates.x;
-      const dy = bar.y - ctx.params.coordinates.y;
-      const distanceMeters = Math.sqrt(dx * dx + dy * dy); // LKS-94 (EPSG:3346) units are meters
-      return distanceMeters < 5;
-    } catch {
-      // Jei QGIS nepasiekiamas, nepriimam sprendimo — leidžiam client'o flag'ui
-      // įtaką (caller'is sprendžia kaip elgtis su `false` rezultatu).
-      return false;
-    }
-  }
-
   @Action({
     rest: 'GET /fishing_sections',
     cache: {

--- a/services/toolsGroups.service.ts
+++ b/services/toolsGroups.service.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import moleculer, { Context } from 'moleculer';
-import { Action, Service } from 'moleculer-decorators';
+import { Action, Method, Service } from 'moleculer-decorators';
 import DbConnection from '../mixins/database.mixin';
 import ProfileMixin from '../mixins/profile.mixin';
 import { coordinatesToGeometry } from '../modules/geometry';
@@ -316,6 +316,7 @@ export default class ToolsGroupsService extends moleculer.Service {
       id: 'number|convert',
       coordinates: CoordinatesProp,
       location: LocationProp,
+      locationManual: { type: 'boolean', optional: true, convert: true },
     },
   })
   async buildTools(
@@ -323,6 +324,7 @@ export default class ToolsGroupsService extends moleculer.Service {
       id: number;
       coordinates: Coordinates;
       location: Location;
+      locationManual?: boolean;
     }>,
   ) {
     const group: ToolsGroup<'tools'> = await ctx.call('toolsGroups.resolve', {
@@ -341,10 +343,19 @@ export default class ToolsGroupsService extends moleculer.Service {
 
     const geom = coordinatesToGeometry(ctx.params.coordinates);
 
+    const locationManual = await this.deriveLocationManual(
+      ctx,
+      currentFishing,
+      ctx.params.location,
+      ctx.params.coordinates,
+      ctx.params.locationManual,
+    );
+
     const buildEvent: ToolsGroupsEvent = await ctx.call('toolsGroupsEvents.create', {
       type: ToolsGroupHistoryTypes.BUILD_TOOLS,
       geom,
       location: ctx.params.location,
+      locationManual,
       fishing: currentFishing.id,
     });
 
@@ -368,6 +379,7 @@ export default class ToolsGroupsService extends moleculer.Service {
       id: 'number|convert',
       coordinates: CoordinatesProp,
       location: LocationProp,
+      locationManual: { type: 'boolean', optional: true, convert: true },
     },
   })
   async removeTools(
@@ -376,6 +388,7 @@ export default class ToolsGroupsService extends moleculer.Service {
         id: number;
         coordinates: Coordinates;
         location: Location;
+        locationManual?: boolean;
       },
       UserAuthMeta
     >,
@@ -396,10 +409,20 @@ export default class ToolsGroupsService extends moleculer.Service {
       throw new moleculer.Errors.ValidationError('Fishing not started');
     }
     const geom = coordinatesToGeometry(ctx.params.coordinates);
+
+    const locationManual = await this.deriveLocationManual(
+      ctx,
+      currentFishing,
+      ctx.params.location,
+      ctx.params.coordinates,
+      ctx.params.locationManual,
+    );
+
     const removeEvent: ToolsGroupsEvent = await ctx.call('toolsGroupsEvents.create', {
       type: ToolsGroupHistoryTypes.REMOVE_TOOLS,
       geom,
       location: ctx.params.location,
+      locationManual,
       fishing: currentFishing.id,
     });
 
@@ -429,6 +452,7 @@ export default class ToolsGroupsService extends moleculer.Service {
       id: 'number|convert',
       coordinates: CoordinatesProp,
       location: LocationProp,
+      locationManual: { type: 'boolean', optional: true, convert: true },
       data: 'object',
     },
   })
@@ -438,15 +462,26 @@ export default class ToolsGroupsService extends moleculer.Service {
         id: number;
         coordinates: Coordinates;
         location: Location;
+        locationManual?: boolean;
         data: { [key: FishType['id']]: number };
       },
       UserAuthMeta
     >,
   ) {
+    const currentFishing: Fishing = await ctx.call('fishings.currentFishing');
+    const locationManual = await this.deriveLocationManual(
+      ctx,
+      currentFishing,
+      ctx.params.location,
+      ctx.params.coordinates,
+      ctx.params.locationManual,
+    );
+
     await ctx.call('weightEvents.createWeightEvent', {
       toolsGroup: ctx.params.id,
       coordinates: ctx.params.coordinates,
       location: ctx.params.location,
+      locationManual,
       data: ctx.params.data,
     });
     return { success: true };
@@ -567,5 +602,36 @@ export default class ToolsGroupsService extends moleculer.Service {
         WHERE location IS NOT NULL AND (location->>'name') NOT ILIKE '%baras%';`,
     );
     return Number(locations[0]?.location_count);
+  }
+
+  @Method
+  async deriveLocationManual(
+    ctx: Context,
+    fishing: Fishing | null,
+    location: Location | undefined,
+    coordinates: Coordinates | undefined,
+    clientHint?: boolean,
+  ): Promise<boolean> {
+    // Sprendimas yra autoritetinis serveryje:
+    // - ESTUARY (Kuršių marios) — patikrinam ar `coordinates` sutampa su
+    //   pasirinkto baro centroidu. Klientas-mobile manual atveju siunčia
+    //   bar centroid kaip event coords, GPS atveju — faktines telefono
+    //   koordinates baro poligone. Centroid'o tikslus sutapimas = manual.
+    // - Kitiems žvejybos tipams (POLDERS, INLAND_WATERS) — kol kas
+    //   pasitikim klientu (admin reikalavimas tik Kuršių marioms).
+    if (
+      fishing?.type === ('ESTUARY' as any) &&
+      location?.id &&
+      coordinates &&
+      typeof coordinates.x === 'number' &&
+      typeof coordinates.y === 'number'
+    ) {
+      const detected: boolean = await ctx.call('locations.isEstuaryLocationManual', {
+        locationId: String(location.id),
+        coordinates,
+      });
+      return detected;
+    }
+    return !!clientHint;
   }
 }

--- a/services/toolsGroups.service.ts
+++ b/services/toolsGroups.service.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import moleculer, { Context } from 'moleculer';
-import { Action, Method, Service } from 'moleculer-decorators';
+import { Action, Service } from 'moleculer-decorators';
 import DbConnection from '../mixins/database.mixin';
 import ProfileMixin from '../mixins/profile.mixin';
 import { coordinatesToGeometry } from '../modules/geometry';
@@ -343,19 +343,11 @@ export default class ToolsGroupsService extends moleculer.Service {
 
     const geom = coordinatesToGeometry(ctx.params.coordinates);
 
-    const locationManual = await this.deriveLocationManual(
-      ctx,
-      currentFishing,
-      ctx.params.location,
-      ctx.params.coordinates,
-      ctx.params.locationManual,
-    );
-
     const buildEvent: ToolsGroupsEvent = await ctx.call('toolsGroupsEvents.create', {
       type: ToolsGroupHistoryTypes.BUILD_TOOLS,
       geom,
       location: ctx.params.location,
-      locationManual,
+      locationManual: !!ctx.params.locationManual,
       fishing: currentFishing.id,
     });
 
@@ -409,20 +401,11 @@ export default class ToolsGroupsService extends moleculer.Service {
       throw new moleculer.Errors.ValidationError('Fishing not started');
     }
     const geom = coordinatesToGeometry(ctx.params.coordinates);
-
-    const locationManual = await this.deriveLocationManual(
-      ctx,
-      currentFishing,
-      ctx.params.location,
-      ctx.params.coordinates,
-      ctx.params.locationManual,
-    );
-
     const removeEvent: ToolsGroupsEvent = await ctx.call('toolsGroupsEvents.create', {
       type: ToolsGroupHistoryTypes.REMOVE_TOOLS,
       geom,
       location: ctx.params.location,
-      locationManual,
+      locationManual: !!ctx.params.locationManual,
       fishing: currentFishing.id,
     });
 
@@ -468,20 +451,11 @@ export default class ToolsGroupsService extends moleculer.Service {
       UserAuthMeta
     >,
   ) {
-    const currentFishing: Fishing = await ctx.call('fishings.currentFishing');
-    const locationManual = await this.deriveLocationManual(
-      ctx,
-      currentFishing,
-      ctx.params.location,
-      ctx.params.coordinates,
-      ctx.params.locationManual,
-    );
-
     await ctx.call('weightEvents.createWeightEvent', {
       toolsGroup: ctx.params.id,
       coordinates: ctx.params.coordinates,
       location: ctx.params.location,
-      locationManual,
+      locationManual: !!ctx.params.locationManual,
       data: ctx.params.data,
     });
     return { success: true };
@@ -602,36 +576,5 @@ export default class ToolsGroupsService extends moleculer.Service {
         WHERE location IS NOT NULL AND (location->>'name') NOT ILIKE '%baras%';`,
     );
     return Number(locations[0]?.location_count);
-  }
-
-  @Method
-  async deriveLocationManual(
-    ctx: Context,
-    fishing: Fishing | null,
-    location: Location | undefined,
-    coordinates: Coordinates | undefined,
-    clientHint?: boolean,
-  ): Promise<boolean> {
-    // Sprendimas yra autoritetinis serveryje:
-    // - ESTUARY (Kuršių marios) — patikrinam ar `coordinates` sutampa su
-    //   pasirinkto baro centroidu. Klientas-mobile manual atveju siunčia
-    //   bar centroid kaip event coords, GPS atveju — faktines telefono
-    //   koordinates baro poligone. Centroid'o tikslus sutapimas = manual.
-    // - Kitiems žvejybos tipams (POLDERS, INLAND_WATERS) — kol kas
-    //   pasitikim klientu (admin reikalavimas tik Kuršių marioms).
-    if (
-      fishing?.type === ('ESTUARY' as any) &&
-      location?.id &&
-      coordinates &&
-      typeof coordinates.x === 'number' &&
-      typeof coordinates.y === 'number'
-    ) {
-      const detected: boolean = await ctx.call('locations.isEstuaryLocationManual', {
-        locationId: String(location.id),
-        coordinates,
-      });
-      return detected;
-    }
-    return !!clientHint;
   }
 }

--- a/services/toolsGroupsEvents.service.ts
+++ b/services/toolsGroupsEvents.service.ts
@@ -31,6 +31,7 @@ interface Fields extends CommonFields {
       name: string;
     };
   };
+  locationManual: boolean;
   data: any;
   fishing: Fishing['id'];
 }
@@ -85,6 +86,10 @@ export type ToolsGroupsEvent<
             },
           },
         },
+      },
+      locationManual: {
+        type: 'boolean',
+        default: false,
       },
       data: 'any', // Type is not clear yet
       fishing: {

--- a/services/weightEvents.service.ts
+++ b/services/weightEvents.service.ts
@@ -30,6 +30,7 @@ interface Fields extends CommonFields {
   date: string;
   geom: any;
   location: Location;
+  locationManual: boolean;
   fishing: Fishing['id'];
   toolsGroup: ToolsGroup['id'];
   tenant: Tenant['id'];
@@ -117,6 +118,10 @@ export type WeightEvent<
       location: {
         ...LocationProp,
         required: false,
+      },
+      locationManual: {
+        type: 'boolean',
+        default: false,
       },
       tenant: {
         type: 'number',
@@ -236,6 +241,7 @@ export default class ToolTypesService extends moleculer.Service {
         ...LocationProp,
         optional: true,
       },
+      locationManual: { type: 'boolean', optional: true, convert: true },
       data: 'object',
     },
   })
@@ -245,6 +251,7 @@ export default class ToolTypesService extends moleculer.Service {
       coordinates: Coordinates;
       data: { [key: FishType['id']]: number };
       location?: Location;
+      locationManual?: boolean;
     }>,
   ) {
     return this.createEntity(ctx, { ...ctx.params });


### PR DESCRIPTION
## Summary

Two related compliance improvements for fishing-event location & catch tracking:

### 1. Manual location flag
- New `location_manual` boolean column on `tools_groups_events` and `weight_events` (default false). Populated from the mobile client's `locationManual` hint sent on build / remove / weigh actions.
- Surfaced in `getHistory` payload per event + a virtual `hasManualLocation` flag on Fishing rows for the journal list.
- **Trust model:** the flag is a compliance hint, not a security boundary. Pure web context can't prevent client-side spoofing; revisit later if abuse shows up (polygon-membership check, native attestation).

### 2. Require every boat-caught fish to appear onshore (NEW)
- `weighFish` now rejects requests where the preliminary (boat-side) catch contains a fish type missing from the onshore `data`.
- Value can be 0 kg (fisher released everything back), but the key has to be present.
- Why: previously, undersize / non-commercial fish (e.g. "Sterkas (neverslinio dydžio)") could silently disappear from the final report when the fisher left the field blank on the shore weighing screen.

## Test plan

- [ ] Run `yarn db:migrate` and verify columns exist on both event tables.
- [ ] GPS auto-detect build → row has `locationManual=false`. Manual picker → `true`.
- [ ] `GET /fishings` rows include `hasManualLocation`.
- [ ] `POST /fishings/weight` succeeds when every preliminary key is in `data` (any value including 0).
- [ ] `POST /fishings/weight` rejects with `MISSING_ONSHORE_WEIGHT` + `missingFishTypeIds` when a preliminary key is missing.
- [ ] POLDERS / INLAND_WATERS flows still work with default `locationManual=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)