### PR TITLE
fix(toolsGroups): surface in-progress bars via notChecked popup

### DIFF
--- a/services/toolsGroups.service.ts
+++ b/services/toolsGroups.service.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import moleculer, { Context } from 'moleculer';
-import { Action, Method, Service } from 'moleculer-decorators';
+import { Action, Service } from 'moleculer-decorators';
 import DbConnection from '../mixins/database.mixin';
 import ProfileMixin from '../mixins/profile.mixin';
 import { coordinatesToGeometry } from '../modules/geometry';
@@ -400,16 +400,6 @@ export default class ToolsGroupsService extends moleculer.Service {
     if (!currentFishing) {
       throw new moleculer.Errors.ValidationError('Fishing not started');
     }
-
-    // Guard: don't let the user return the last unchecked tool of a type
-    // when sibling tools of the same type were only marked "Patikrinta"
-    // (empty `data: {}` weight event) and no fish has been recorded
-    // anywhere for this type. The "Patikrinta" shortcut is only meant for
-    // duplicates of an already-weighed catch — if every sibling event is
-    // empty, the catch was never logged. Forces the user to weigh fish
-    // before all evidence of this tool type disappears.
-    await this.assertSiblingsHaveFishLogged(ctx, group, currentFishing);
-
     const geom = coordinatesToGeometry(ctx.params.coordinates);
     const removeEvent: ToolsGroupsEvent = await ctx.call('toolsGroupsEvents.create', {
       type: ToolsGroupHistoryTypes.REMOVE_TOOLS,
@@ -538,20 +528,28 @@ export default class ToolsGroupsService extends moleculer.Service {
       query: { fishing: currentFishing.id },
     });
 
-    const checkedToolsGroupIds = new Set(
-      weightEvents
-        .map((w) => w.toolsGroup?.id)
-        .filter((id): id is number => id != null),
-    );
+    // Map<toolsGroup.id, hasAnyFishLogged> — a "Patikrinta" press writes a
+    // weight_event with `data: {}`, so we need to look at the payload to
+    // tell apart "checked-with-fish" from "checked-empty".
+    const weightByGroup = new Map<number, boolean>();
+    for (const w of weightEvents) {
+      const groupId = w.toolsGroup?.id;
+      if (groupId == null) continue;
+      const hasFish = !!w.data && Object.keys(w.data).length > 0;
+      weightByGroup.set(groupId, weightByGroup.get(groupId) || hasFish);
+    }
 
     const locationStats = new Map<
       string,
-      { name: string; checked: number; unchecked: number }
+      { name: string; checked: number; unchecked: number; withFish: number }
     >();
     for (const group of notRemovedToolsGroups) {
       const buildFishing = group.buildEvent?.fishing;
+      // Different fishing type → not our concern (e.g. ESTUARY vs INLAND).
+      // Previously also skipped the current fishing entirely, but the user
+      // needs to be warned when they cross over to a new bar leaving an
+      // earlier bar of the same trip half-finished.
       if (buildFishing?.type !== currentFishing.type) continue;
-      if (buildFishing?.id === currentFishing.id) continue;
       const location = group.buildEvent?.location;
       if (!location?.id) continue;
       const key = String(location.id);
@@ -559,9 +557,11 @@ export default class ToolsGroupsService extends moleculer.Service {
         name: location.name ?? '',
         checked: 0,
         unchecked: 0,
+        withFish: 0,
       };
-      if (checkedToolsGroupIds.has(group.id)) {
+      if (weightByGroup.has(group.id)) {
         entry.checked += 1;
+        if (weightByGroup.get(group.id)) entry.withFish += 1;
       } else {
         entry.unchecked += 1;
       }
@@ -569,7 +569,14 @@ export default class ToolsGroupsService extends moleculer.Service {
     }
 
     return Array.from(locationStats.entries())
-      .filter(([, stats]) => stats.checked > 0 && stats.unchecked > 0)
+      .filter(([, stats]) => {
+        // Surface bars that are still "in progress": either some tools are
+        // unchecked, or every checked one is an empty Patikrinta (no fish
+        // logged yet). Fully-weighed bars with no leftover tools fall out.
+        if (stats.unchecked > 0 && stats.checked > 0) return true;
+        if (stats.checked > 0 && stats.withFish === 0) return true;
+        return false;
+      })
       .map(([id, stats]) => ({ id, name: stats.name }));
   }
 
@@ -588,57 +595,4 @@ export default class ToolsGroupsService extends moleculer.Service {
     return Number(locations[0]?.location_count);
   }
 
-  @Method
-  async assertSiblingsHaveFishLogged(
-    ctx: Context,
-    group: ToolsGroup<'tools'>,
-    currentFishing: Fishing,
-  ) {
-    const toolTypeId = (group.tools?.[0] as Tool<'toolType'> | undefined)?.toolType?.id;
-    if (!toolTypeId) return;
-
-    // Same shape as `getNotCheckedToolsGroups` — find returns user-scoped
-    // groups, IDs come back encoded so comparisons match `currentFishing.id`
-    // without us having to think about `secure: true` decoding.
-    const activeGroups: ToolsGroup<'tools' | 'buildEvent'>[] = await ctx.call(
-      'toolsGroups.find',
-      {
-        query: { removeEvent: { $exists: false } },
-        populate: ['tools', 'buildEvent'],
-      },
-    );
-
-    const siblings = activeGroups.filter((g) => {
-      const sameFishing = g.buildEvent?.fishing?.id === currentFishing.id;
-      const sameType = (g.tools as Tool<'toolType'>[] | undefined)?.some(
-        (t) => t?.toolType?.id === toolTypeId,
-      );
-      return sameFishing && sameType;
-    });
-
-    if (!siblings.length) return;
-
-    const siblingIds = siblings.map((g) => g.id);
-    const sibWeights: WeightEvent[] = await ctx.call('weightEvents.find', {
-      query: { fishing: currentFishing.id, toolsGroup: { $in: siblingIds } },
-    });
-
-    const checkedGroupIds = new Set(
-      sibWeights.map((w) => w.toolsGroup).filter((id) => id != null),
-    );
-    if (checkedGroupIds.has(group.id)) return; // self already weighed/checked — allow
-
-    const anyWithFish = sibWeights.some(
-      (w) => w.data && Object.keys(w.data).length > 0,
-    );
-    const unchecked = siblings.length - checkedGroupIds.size;
-
-    // We're the last unchecked of this type AND siblings only have empty
-    // "patikrinta" events → returning now would lose the catch.
-    if (unchecked === 1 && checkedGroupIds.size > 0 && !anyWithFish) {
-      throw new moleculer.Errors.ValidationError(
-        'Negalima grąžinti įrankio į sandėlį, kol nepasvertos žuvys: kiti to paties tipo įrankiai pažymėti kaip patikrinti, bet žuvies svoris dar neįrašytas.',
-      );
-    }
-  }
 }

--- a/services/toolsGroups.service.ts
+++ b/services/toolsGroups.service.ts
@@ -408,7 +408,7 @@ export default class ToolsGroupsService extends moleculer.Service {
     // duplicates of an already-weighed catch — if every sibling event is
     // empty, the catch was never logged. Forces the user to weigh fish
     // before all evidence of this tool type disappears.
-    await this.assertSiblingsHaveFishLogged(ctx, group, currentFishing.id);
+    await this.assertSiblingsHaveFishLogged(ctx, group, currentFishing);
 
     const geom = coordinatesToGeometry(ctx.params.coordinates);
     const removeEvent: ToolsGroupsEvent = await ctx.call('toolsGroupsEvents.create', {
@@ -592,60 +592,50 @@ export default class ToolsGroupsService extends moleculer.Service {
   async assertSiblingsHaveFishLogged(
     ctx: Context,
     group: ToolsGroup<'tools'>,
-    fishingId: number,
+    currentFishing: Fishing,
   ) {
     const toolTypeId = (group.tools?.[0] as Tool<'toolType'> | undefined)?.toolType?.id;
     if (!toolTypeId) return;
 
-    const ownWeights: WeightEvent[] = await ctx.call('weightEvents.find', {
-      query: { fishing: fishingId, toolsGroup: group.id },
-      limit: 1,
-    });
-    if (ownWeights.length > 0) return; // self already has a weight event — let it through
-
-    // Aggregate per-tool-type in the current fishing. Raw SQL because tools
-    // are stored as an integer[] on tools_groups and the moleculer-db DSL
-    // can't express ANY(tools) joins. See CLAUDE.md → "Virtual-field
-    // populate gotchas" for why we don't run this through populate.
-    const rows: Array<{
-      built_count: string;
-      checked_count: string;
-      with_fish_count: string;
-    }> = await this.rawQuery(
-      ctx,
-      `SELECT
-         COUNT(DISTINCT tg.id) AS built_count,
-         COUNT(DISTINCT we.tools_group_id) AS checked_count,
-         COUNT(DISTINCT CASE
-           WHEN we.data IS NOT NULL AND we.data::text <> '{}'
-           THEN we.tools_group_id
-         END) AS with_fish_count
-       FROM tools_groups tg
-       JOIN tools_groups_events build ON tg.build_event_id = build.id
-       LEFT JOIN weight_events we
-         ON we.tools_group_id = tg.id
-         AND we.fishing_id = build.fishing_id
-         AND we.deleted_at IS NULL
-       WHERE tg.deleted_at IS NULL
-         AND tg.remove_event_id IS NULL
-         AND build.fishing_id = ?
-         AND EXISTS (
-           SELECT 1 FROM tools t
-           WHERE t.id = ANY(tg.tools) AND t.tool_type_id = ?
-         )`,
-      [fishingId, toolTypeId],
+    // Same shape as `getNotCheckedToolsGroups` — find returns user-scoped
+    // groups, IDs come back encoded so comparisons match `currentFishing.id`
+    // without us having to think about `secure: true` decoding.
+    const activeGroups: ToolsGroup<'tools' | 'buildEvent'>[] = await ctx.call(
+      'toolsGroups.find',
+      {
+        query: { removeEvent: { $exists: false } },
+        populate: ['tools', 'buildEvent'],
+      },
     );
 
-    const stats = rows?.[0];
-    if (!stats) return;
-    const built = Number(stats.built_count) || 0;
-    const checked = Number(stats.checked_count) || 0;
-    const withFish = Number(stats.with_fish_count) || 0;
-    const unchecked = built - checked;
+    const siblings = activeGroups.filter((g) => {
+      const sameFishing = g.buildEvent?.fishing?.id === currentFishing.id;
+      const sameType = (g.tools as Tool<'toolType'>[] | undefined)?.some(
+        (t) => t?.toolType?.id === toolTypeId,
+      );
+      return sameFishing && sameType;
+    });
+
+    if (!siblings.length) return;
+
+    const siblingIds = siblings.map((g) => g.id);
+    const sibWeights: WeightEvent[] = await ctx.call('weightEvents.find', {
+      query: { fishing: currentFishing.id, toolsGroup: { $in: siblingIds } },
+    });
+
+    const checkedGroupIds = new Set(
+      sibWeights.map((w) => w.toolsGroup).filter((id) => id != null),
+    );
+    if (checkedGroupIds.has(group.id)) return; // self already weighed/checked — allow
+
+    const anyWithFish = sibWeights.some(
+      (w) => w.data && Object.keys(w.data).length > 0,
+    );
+    const unchecked = siblings.length - checkedGroupIds.size;
 
     // We're the last unchecked of this type AND siblings only have empty
     // "patikrinta" events → returning now would lose the catch.
-    if (unchecked === 1 && checked > 0 && withFish === 0) {
+    if (unchecked === 1 && checkedGroupIds.size > 0 && !anyWithFish) {
       throw new moleculer.Errors.ValidationError(
         'Negalima grąžinti įrankio į sandėlį, kol nepasvertos žuvys: kiti to paties tipo įrankiai pažymėti kaip patikrinti, bet žuvies svoris dar neįrašytas.',
       );

--- a/services/toolsGroups.service.ts
+++ b/services/toolsGroups.service.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import moleculer, { Context } from 'moleculer';
-import { Action, Service } from 'moleculer-decorators';
+import { Action, Method, Service } from 'moleculer-decorators';
 import DbConnection from '../mixins/database.mixin';
 import ProfileMixin from '../mixins/profile.mixin';
 import { coordinatesToGeometry } from '../modules/geometry';
@@ -400,6 +400,16 @@ export default class ToolsGroupsService extends moleculer.Service {
     if (!currentFishing) {
       throw new moleculer.Errors.ValidationError('Fishing not started');
     }
+
+    // Guard: don't let the user return the last unchecked tool of a type
+    // when sibling tools of the same type were only marked "Patikrinta"
+    // (empty `data: {}` weight event) and no fish has been recorded
+    // anywhere for this type. The "Patikrinta" shortcut is only meant for
+    // duplicates of an already-weighed catch — if every sibling event is
+    // empty, the catch was never logged. Forces the user to weigh fish
+    // before all evidence of this tool type disappears.
+    await this.assertSiblingsHaveFishLogged(ctx, group, currentFishing.id);
+
     const geom = coordinatesToGeometry(ctx.params.coordinates);
     const removeEvent: ToolsGroupsEvent = await ctx.call('toolsGroupsEvents.create', {
       type: ToolsGroupHistoryTypes.REMOVE_TOOLS,
@@ -570,11 +580,75 @@ export default class ToolsGroupsService extends moleculer.Service {
     const locations = await this.rawQuery(
       ctx,
       `SELECT COUNT(DISTINCT (location->>'id')::text) +
-        CASE WHEN EXISTS ( SELECT 1 FROM tools_groups_events WHERE location IS NOT NULL AND (location->>'name') ILIKE '%baras%') 
+        CASE WHEN EXISTS ( SELECT 1 FROM tools_groups_events WHERE location IS NOT NULL AND (location->>'name') ILIKE '%baras%')
         THEN 1 ELSE 0 END AS location_count
         FROM tools_groups_events
         WHERE location IS NOT NULL AND (location->>'name') NOT ILIKE '%baras%';`,
     );
     return Number(locations[0]?.location_count);
+  }
+
+  @Method
+  async assertSiblingsHaveFishLogged(
+    ctx: Context,
+    group: ToolsGroup<'tools'>,
+    fishingId: number,
+  ) {
+    const toolTypeId = (group.tools?.[0] as Tool<'toolType'> | undefined)?.toolType?.id;
+    if (!toolTypeId) return;
+
+    const ownWeights: WeightEvent[] = await ctx.call('weightEvents.find', {
+      query: { fishing: fishingId, toolsGroup: group.id },
+      limit: 1,
+    });
+    if (ownWeights.length > 0) return; // self already has a weight event — let it through
+
+    // Aggregate per-tool-type in the current fishing. Raw SQL because tools
+    // are stored as an integer[] on tools_groups and the moleculer-db DSL
+    // can't express ANY(tools) joins. See CLAUDE.md → "Virtual-field
+    // populate gotchas" for why we don't run this through populate.
+    const rows: Array<{
+      built_count: string;
+      checked_count: string;
+      with_fish_count: string;
+    }> = await this.rawQuery(
+      ctx,
+      `SELECT
+         COUNT(DISTINCT tg.id) AS built_count,
+         COUNT(DISTINCT we.tools_group_id) AS checked_count,
+         COUNT(DISTINCT CASE
+           WHEN we.data IS NOT NULL AND we.data::text <> '{}'
+           THEN we.tools_group_id
+         END) AS with_fish_count
+       FROM tools_groups tg
+       JOIN tools_groups_events build ON tg.build_event_id = build.id
+       LEFT JOIN weight_events we
+         ON we.tools_group_id = tg.id
+         AND we.fishing_id = build.fishing_id
+         AND we.deleted_at IS NULL
+       WHERE tg.deleted_at IS NULL
+         AND tg.remove_event_id IS NULL
+         AND build.fishing_id = ?
+         AND EXISTS (
+           SELECT 1 FROM tools t
+           WHERE t.id = ANY(tg.tools) AND t.tool_type_id = ?
+         )`,
+      [fishingId, toolTypeId],
+    );
+
+    const stats = rows?.[0];
+    if (!stats) return;
+    const built = Number(stats.built_count) || 0;
+    const checked = Number(stats.checked_count) || 0;
+    const withFish = Number(stats.with_fish_count) || 0;
+    const unchecked = built - checked;
+
+    // We're the last unchecked of this type AND siblings only have empty
+    // "patikrinta" events → returning now would lose the catch.
+    if (unchecked === 1 && checked > 0 && withFish === 0) {
+      throw new moleculer.Errors.ValidationError(
+        'Negalima grąžinti įrankio į sandėlį, kol nepasvertos žuvys: kiti to paties tipo įrankiai pažymėti kaip patikrinti, bet žuvies svoris dar neįrašytas.',
+      );
+    }
   }
 }


### PR DESCRIPTION
## Summary

Reshape `toolsGroups/notChecked` so the existing `Nepatikrinti įrankiai` popup catches both field reports — no hard block on remove.

- **Include the current fishing.** Previously the endpoint skipped groups built in the same fishing as `currentFishing`, so a user crossing from bar A to bar B with unchecked nets at A got no warning (*"Pereinu į kitą barą — nerašo kad buvusiame bare dar liko 2 nepatikrinti tinklai"*).
- **Treat empty-`data: {}` weight events as "in progress".** Pressing **Patikrinta** writes a weight event with no fish payload; the bar where every event is empty should still be flagged so the user weighs before walking away.
- Drops the earlier `assertSiblingsHaveFishLogged` raw-SQL guard — wrong tool for the job: it also passed the encoded `currentFishing.id` straight to Postgres, so it would have silently zero-matched in production.

## Test plan
- [ ] Build 3 nets in bar A, Patikrinta on 1, move to bar B → popup lists bar A.
- [ ] Build 3 nets in bar A, Patikrinta on all 3 (no fish), move to bar B → popup lists bar A.
- [ ] Build 3 nets in bar A, weigh fish on 1 → popup does not list bar A.
- [ ] Cross-fishing leftovers (previous fishing's in-water tools) still surface.
- [ ] Fully-weighed bar (all nets weighed, none left) → popup empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)