### PR TITLE
fix(history): return event coordinates as {lat, lng}

### DIFF
--- a/modules/geometry.ts
+++ b/modules/geometry.ts
@@ -57,9 +57,12 @@ export function coordinatesToGeometry(coordinates: { x: number; y: number }) {
   };
 }
 
-export function geomToWgs(geom: GeomFeatureCollection) {
-  const lks = geom.features[0].geometry.coordinates as CoordinatesPoint;
+export function geomToWgs(geom: GeomFeatureCollection): { lat: number; lng: number } | null {
+  const lks = geom?.features?.[0]?.geometry?.coordinates as CoordinatesPoint | undefined;
+  if (!lks || lks.length < 2) return null;
   const transform = transformation('3346', 'EPSG:4326');
-  const coordinates = { x: lks[0], y: lks[1] };
-  return transform.forward(coordinates);
+  // proj4 returns `{ x: lng, y: lat }` for EPSG:4326 — expose lat/lng
+  // explicitly so consumers don't have to remember which axis is which.
+  const wgs = transform.forward({ x: lks[0], y: lks[1] });
+  return { lat: wgs.y, lng: wgs.x };
 }

--- a/services/fishings.service.ts
+++ b/services/fishings.service.ts
@@ -50,7 +50,7 @@ type Event = {
   type: EventType;
   date: Date;
   geom: any;
-  coordinates?: Coordinates;
+  coordinates?: { lat: number; lng: number } | null;
   location?: any;
   locationManual?: boolean;
   data?: any;


### PR DESCRIPTION
## Summary
- `geomToWgs` returned `{ x: lng, y: lat }` from proj4 — fine for spatial math, confusing for every UI that has to print or paste a coord.
- Two real bugs traced back to that naming:
  - **biip-zvejyba-web** ([FishingEventDetails#146](https://github.com/AplinkosMinisterija/biip-zvejyba-web/pull/146)) was printing the coordinates as `x, y` (lng-first), unlike admin and the convention Google Maps wants.
  - **biip-admin-web** swaps them manually in the `getEventCoordinates` fallback (`[item.coordinates.y, item.coordinates.x]`).
- Helper now returns `{ lat, lng }` directly. `getHistory` is the only caller; the response field is self-describing and clients can just destructure.

## Coordinated PRs
- biip-zvejyba-web PR consuming new shape: AplinkosMinisterija/biip-zvejyba-web#146 (updated alongside this)
- biip-admin-web fallback cleanup: pending

## Test plan
- [ ] `GET /fishings/history/:id` response: every event has `coordinates: { lat: <number>, lng: <number> }`.
- [ ] Admin journal still renders coords correctly (it reads from `event.geom`, not `event.coordinates`).
- [ ] Web detail view shows lat first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)