### PR TITLE
fix(toolsGroups): block warehouse return when bar siblings only have empty Patikrinta

### DIFF
--- a/services/toolsGroups.service.ts
+++ b/services/toolsGroups.service.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import moleculer, { Context } from 'moleculer';
-import { Action, Service } from 'moleculer-decorators';
+import { Action, Method, Service } from 'moleculer-decorators';
 import DbConnection from '../mixins/database.mixin';
 import ProfileMixin from '../mixins/profile.mixin';
 import { coordinatesToGeometry } from '../modules/geometry';
@@ -400,6 +400,14 @@ export default class ToolsGroupsService extends moleculer.Service {
     if (!currentFishing) {
       throw new moleculer.Errors.ValidationError('Fishing not started');
     }
+
+    // Refuse to return the last unchecked tool of a type when every sibling
+    // of the same type only got an empty "Patikrinta" event (weight_event
+    // with `data: {}`). Otherwise the catch is silently lost: the
+    // `notChecked` popup warns the user but they can click past it; the
+    // hard error forces them to weigh fish on at least one tool first.
+    await this.assertSiblingsHaveFishLogged(ctx, group, currentFishing);
+
     const geom = coordinatesToGeometry(ctx.params.coordinates);
     const removeEvent: ToolsGroupsEvent = await ctx.call('toolsGroupsEvents.create', {
       type: ToolsGroupHistoryTypes.REMOVE_TOOLS,
@@ -595,4 +603,62 @@ export default class ToolsGroupsService extends moleculer.Service {
     return Number(locations[0]?.location_count);
   }
 
+  @Method
+  async assertSiblingsHaveFishLogged(
+    ctx: Context,
+    group: ToolsGroup<'tools'>,
+    currentFishing: Fishing,
+  ) {
+    const toolTypeId = (group.tools?.[0] as Tool<'toolType'> | undefined)?.toolType?.id;
+    const ownLocationId = (group as ToolsGroup<'tools' | 'buildEvent'>).buildEvent?.location?.id;
+    if (!toolTypeId || ownLocationId == null) return;
+
+    // Same shape as `getNotCheckedToolsGroups` — `find` returns user-scoped
+    // groups, IDs come back encoded so comparisons match `currentFishing.id`
+    // without us having to think about `secure: true` decoding.
+    const activeGroups: ToolsGroup<'tools' | 'buildEvent'>[] = await ctx.call(
+      'toolsGroups.find',
+      {
+        query: { removeEvent: { $exists: false } },
+        populate: ['tools', 'buildEvent'],
+      },
+    );
+
+    // Scope siblings by fishing + bar/location + tool type. Each bar is a
+    // self-contained checking session — a net weighed with fish in bar 2
+    // doesn't account for an empty "Patikrinta" sibling in bar 1.
+    const siblings = activeGroups.filter((g) => {
+      const sameFishing = g.buildEvent?.fishing?.id === currentFishing.id;
+      const sameLocation = String(g.buildEvent?.location?.id ?? '') === String(ownLocationId);
+      const sameType = (g.tools as Tool<'toolType'>[] | undefined)?.some(
+        (t) => t?.toolType?.id === toolTypeId,
+      );
+      return sameFishing && sameLocation && sameType;
+    });
+
+    if (!siblings.length) return;
+
+    const siblingIds = siblings.map((g) => g.id);
+    const sibWeights: WeightEvent[] = await ctx.call('weightEvents.find', {
+      query: { fishing: currentFishing.id, toolsGroup: { $in: siblingIds } },
+    });
+
+    const checkedGroupIds = new Set(
+      sibWeights.map((w) => w.toolsGroup).filter((id) => id != null),
+    );
+    if (checkedGroupIds.has(group.id)) return; // self already weighed/checked — allow
+
+    const anyWithFish = sibWeights.some(
+      (w) => w.data && Object.keys(w.data).length > 0,
+    );
+    const unchecked = siblings.length - checkedGroupIds.size;
+
+    // We're the last unchecked of this type AND siblings only have empty
+    // "Patikrinta" events → returning now would lose the catch.
+    if (unchecked === 1 && checkedGroupIds.size > 0 && !anyWithFish) {
+      throw new moleculer.Errors.ValidationError(
+        'Negalima grąžinti įrankio į sandėlį, kol nepasvertos žuvys: kiti to paties tipo įrankiai pažymėti kaip patikrinti, bet žuvies svoris dar neįrašytas.',
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Hard guard for Giedrius's field report: 3 identical nets in a bar → user presses **Patikrinta** on two (each writes `weight_event.data = {}`) → tries **Sugrąžinti į sandėlį** on the third without weighing. End of fishing → no catch ever recorded for that tool type.

The [`notChecked` popup from #118](https://github.com/AplinkosMinisterija/biip-zvejyba-api/pull/118) already warns the user, but they can click past it. This adds a server-side block so the catch can't be lost silently.

## Logic

When `removeTools` is called on a group that has **no weight event of its own**, look at siblings — other groups of the **same tool type** in the **same bar/location** of the **same fishing**. If every sibling only has empty `data: {}` events and nothing carries fish, throw a validation error.

- **Scope: fishing + location + type.** Each bar is its own checking session — a net weighed with fish in bar 2 does not account for an empty sibling in bar 1.
- **Self check:** if this group already has a weight event, skip the guard (handles edge cases where someone removes a checked-empty tool while the unchecked one is the real "last").
- **No raw SQL.** Uses `toolsGroups.find` (user-scoped) + `weightEvents.find` keyed by `fishing` + `toolsGroup`. Encoded `currentFishing.id` is compared against same-encoding `g.buildEvent?.fishing?.id` — same pattern as `getNotCheckedToolsGroups`.

## Test plan
- [ ] 3 nets in bar A, Patikrinta on 2 (empty), try to return the 3rd → 400 with Lithuanian error message.
- [ ] Same as above + weigh fish on one of the 2 first → return the 3rd → succeeds.
- [ ] 3 nets in bar A (Patikrinta x2 empty, 1 unchecked) + 3 nets in bar B (all weighed with fish) → returning the bar A unchecked one is still blocked (location-scoped).
- [ ] Single net in a bar, never checked → return → succeeds.
- [ ] Returning a tool that itself has a weight event (with or without fish) → succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)