### PR TITLE
fix(security): close tenant-scope bypass, SQL/NoSQL injection, lock down MinIO

### DIFF
--- a/mixins/profile.mixin.ts
+++ b/mixins/profile.mixin.ts
@@ -1,6 +1,22 @@
 import { Context } from 'moleculer';
 import { AuthUserRole, UserAuthMeta } from '../services/api.service';
 
+// Drop keys that would bypass the tenant/user scope or smuggle raw SQL
+// through moleculer-knex-filters. User-supplied query may still include
+// arbitrary filter fields (label, type, etc.) — we only strip the ones
+// that overlap with what this mixin enforces.
+const FORBIDDEN_USER_QUERY_KEYS = ['tenant', 'user', '$raw'] as const;
+
+function sanitizeUserQuery(query: any) {
+  if (!query || typeof query !== 'object') return {};
+  const clean: Record<string, any> = {};
+  for (const key of Object.keys(query)) {
+    if ((FORBIDDEN_USER_QUERY_KEYS as readonly string[]).includes(key)) continue;
+    clean[key] = query[key];
+  }
+  return clean;
+}
+
 export default {
   methods: {
     beforeSelect(ctx: Context<any, UserAuthMeta>) {
@@ -8,20 +24,27 @@ export default {
         if (
           ![AuthUserRole.SUPER_ADMIN, AuthUserRole.ADMIN].some((r) => r === ctx.meta?.authUser?.type)
         ) {
-          const q = ctx.params.query;
+          // Security clauses MUST be spread last so user-supplied query
+          // (`?query[tenant]=99`, `query.user=99`, or `query.$raw`) cannot
+          // override the tenant/user scope. The previous spread order
+          // (`{ tenant: profile, ...q }`) allowed horizontal privilege
+          // escalation across tenants for every entity that mixes this in.
+          // We also drop `tenant`/`user`/`$raw` keys from `q` defensively,
+          // so the security fields can't be re-injected via `q.<sec-key>`.
+          const q = sanitizeUserQuery(ctx.params.query);
           // tenant profile
           if (ctx.meta.profile && ctx.meta?.user) {
             ctx.params.query = {
-              tenant: ctx.meta.profile,
               ...q,
+              tenant: ctx.meta.profile,
             };
           }
           // personal profile
           if (!ctx.meta.profile && ctx.meta.user) {
             ctx.params.query = {
+              ...q,
               user: ctx.meta.user.id,
               tenant: { $exists: false },
-              ...q,
             };
           }
         }

--- a/package.json
+++ b/package.json
@@ -60,10 +60,11 @@
   "dependencies": {
     "@moleculer/database": "github:ambrazasp/moleculerjs-database",
     "@r2d2bzh/moleculer-cron": "^0.1.4",
-    "exceljs": "^4.4.0",
     "@turf/centroid": "^7.2.0",
     "biip-auth-nodejs": "DadPatch/biip-auth-nodejs",
     "dotenv": "^16.0.3",
+    "exceljs": "^4.4.0",
+    "helmet": "^8.1.0",
     "ioredis": "^5.3.1",
     "knex": "^3.0.1",
     "lodash": "^4.17.21",

--- a/services/api.service.ts
+++ b/services/api.service.ts
@@ -7,29 +7,6 @@ import ApiGateway from 'moleculer-web';
 import { RequestMessage, RestrictionType } from '../types';
 import { User } from './users.service';
 
-// Comma-separated allowlist, e.g.
-// `CORS_ALLOWED_ORIGINS=https://zvejyba.biip.lt,https://www.zvejyba.biip.lt`.
-// When unset, we fall back to a safe default:
-//   - production → known biip.lt fishing-app origins
-//   - anything else → `*` so dev/curl/vite/mobile sim keeps working
-// This lets the security fix land without a same-PR biip-infra change,
-// and the env can be set later to override the default in case the
-// FE origin moves.
-const DEFAULT_PROD_ORIGINS = [
-  'https://zvejyba.biip.lt',
-  'https://staging-zvejyba.biip.lt',
-];
-function resolveCorsOrigin(): string | string[] {
-  const raw = (process.env.CORS_ALLOWED_ORIGINS || '').trim();
-  if (raw) {
-    return raw
-      .split(',')
-      .map((o) => o.trim())
-      .filter(Boolean);
-  }
-  return process.env.NODE_ENV === 'production' ? DEFAULT_PROD_ORIGINS : '*';
-}
-
 export interface UserAuthMeta {
   user: User;
   app: any;
@@ -52,11 +29,14 @@ export enum AuthUserRole {
     port: process.env.PORT || 3000,
     path: '/zvejyba',
 
-    // Global CORS settings for all routes. Driven by CORS_ALLOWED_ORIGINS
-    // env (comma-separated) so prod can lock to known FE origins;
-    // dev/non-prod keeps `*` for ease of curl/vite/mobile testing.
+    // Global CORS settings for all routes. Stays `*` intentionally —
+    // this API serves an unknown set of third-party clients, so a
+    // closed allowlist would break consumers we don't have an inventory
+    // of. Bearer-token auth (not cookies) means the browser doesn't
+    // auto-send credentials cross-origin, which limits the blast
+    // radius of `*`.
     cors: {
-      origin: resolveCorsOrigin(),
+      origin: '*',
       methods: ['GET', 'OPTIONS', 'POST', 'PUT', 'DELETE'],
       allowedHeaders: '*',
       maxAge: 3600,

--- a/services/api.service.ts
+++ b/services/api.service.ts
@@ -1,10 +1,34 @@
 'use strict';
 
+import helmet from 'helmet';
 import moleculer, { Context } from 'moleculer';
 import { Action, Method, Service } from 'moleculer-decorators';
 import ApiGateway from 'moleculer-web';
 import { RequestMessage, RestrictionType } from '../types';
 import { User } from './users.service';
+
+// Comma-separated allowlist, e.g.
+// `CORS_ALLOWED_ORIGINS=https://zvejyba.biip.lt,https://www.zvejyba.biip.lt`.
+// When unset, we fall back to a safe default:
+//   - production → known biip.lt fishing-app origins
+//   - anything else → `*` so dev/curl/vite/mobile sim keeps working
+// This lets the security fix land without a same-PR biip-infra change,
+// and the env can be set later to override the default in case the
+// FE origin moves.
+const DEFAULT_PROD_ORIGINS = [
+  'https://zvejyba.biip.lt',
+  'https://staging-zvejyba.biip.lt',
+];
+function resolveCorsOrigin(): string | string[] {
+  const raw = (process.env.CORS_ALLOWED_ORIGINS || '').trim();
+  if (raw) {
+    return raw
+      .split(',')
+      .map((o) => o.trim())
+      .filter(Boolean);
+  }
+  return process.env.NODE_ENV === 'production' ? DEFAULT_PROD_ORIGINS : '*';
+}
 
 export interface UserAuthMeta {
   user: User;
@@ -24,20 +48,17 @@ export enum AuthUserRole {
   name: 'api',
   mixins: [ApiGateway],
   // More info about settings: https://moleculer.services/docs/0.14/moleculer-web.html
-  // TODO: helmet
   settings: {
     port: process.env.PORT || 3000,
     path: '/zvejyba',
 
-    // Global CORS settings for all routes
+    // Global CORS settings for all routes. Driven by CORS_ALLOWED_ORIGINS
+    // env (comma-separated) so prod can lock to known FE origins;
+    // dev/non-prod keeps `*` for ease of curl/vite/mobile testing.
     cors: {
-      // Configures the Access-Control-Allow-Origin CORS header.
-      origin: '*',
-      // Configures the Access-Control-Allow-Methods CORS header.
+      origin: resolveCorsOrigin(),
       methods: ['GET', 'OPTIONS', 'POST', 'PUT', 'DELETE'],
-      // Configures the Access-Control-Allow-Headers CORS header.
       allowedHeaders: '*',
-      // Configures the Access-Control-Max-Age CORS header.
       maxAge: 3600,
     },
 
@@ -49,8 +70,12 @@ export enum AuthUserRole {
           '**',
         ],
 
-        // Route-level Express middlewares. More info: https://moleculer.services/docs/0.14/moleculer-web.html#Middlewares
-        use: [],
+        // Route-level Express middlewares. Helmet adds standard security
+        // headers (X-Content-Type-Options, Referrer-Policy, HSTS in prod,
+        // etc.). CSP is intentionally disabled — this is a JSON API, not
+        // an HTML surface, and a wrong CSP here breaks the `minio.getFile`
+        // file proxy / xlsx export response without protecting anything.
+        use: [helmet({ contentSecurityPolicy: false })],
 
         // Enable/disable parameter merging method. More info: https://moleculer.services/docs/0.14/moleculer-web.html#Disable-merging
         mergeParams: true,

--- a/services/minio.service.ts
+++ b/services/minio.service.ts
@@ -32,6 +32,12 @@ export const BUCKET_NAME = () => process.env.MINIO_BUCKET || 'zvejyba';
 })
 export default class MinioService extends Moleculer.Service {
   @Action({
+    // Internal helper — never expose over HTTP. Without `rest: null`,
+    // `mappingPolicy: 'all'` on the api gateway would auto-publish this
+    // at `/minio/get-url` and any authenticated USER could enumerate
+    // signed/private URLs for arbitrary objects.
+    rest: null,
+    auth: RestrictionType.ADMIN,
     params: {
       bucketName: {
         type: 'string',
@@ -58,6 +64,13 @@ export default class MinioService extends Moleculer.Service {
   }
 
   @Action({
+    // Wrapping callers (`researches.upload`, `fishTypes.upload`) reach
+    // this via internal `ctx.call`, which bypasses the gateway auth
+    // boundary — so locking the HTTP surface to ADMIN does NOT break
+    // those flows. It only prevents authenticated USERs from POSTing
+    // raw multipart bodies straight at `/minio/upload-file`.
+    rest: null,
+    auth: RestrictionType.ADMIN,
     params: {
       folder: 'string',
       types: {
@@ -158,7 +171,14 @@ export default class MinioService extends Moleculer.Service {
         },
       },
     },
-    auth: RestrictionType.PUBLIC,
+    // Was PUBLIC — let any unauthenticated caller read any private
+    // object via the service's MinIO root credentials (see /cso audit
+    // Finding #2). Now requires an authenticated USER (or higher);
+    // truly public assets (e.g. fishType photos in `uploads/fishTypes/*`)
+    // should be served via the direct MinIO URL returned by
+    // `minio.getObjectUrl()` — the bucket policy in `started()` already
+    // allows anonymous S3 GET on that prefix.
+    auth: RestrictionType.USER,
     rest: 'GET /:bucket/:name+',
   })
   async getFile(
@@ -193,6 +213,9 @@ export default class MinioService extends Moleculer.Service {
   }
 
   @Action({
+    // Internal-only — see `getUrl`/`uploadFile` for the rationale.
+    rest: null,
+    auth: RestrictionType.ADMIN,
     params: {
       objectName: 'string',
       bucketName: {
@@ -231,6 +254,13 @@ export default class MinioService extends Moleculer.Service {
   }
 
   @Action({
+    // Was auto-exposed at `POST /minio/remove-file` with `auth: DEFAULT`,
+    // letting any authenticated USER pass `{ path: "<bucket>/<other-user-file>" }`
+    // and delete arbitrary objects (no ownership check). See /cso audit
+    // Finding #3. Lock to ADMIN over HTTP; internal callers (if any)
+    // still reach it via `ctx.call`.
+    rest: null,
+    auth: RestrictionType.ADMIN,
     params: {
       path: 'string',
     },

--- a/services/users.service.ts
+++ b/services/users.service.ts
@@ -17,6 +17,21 @@ import DbConnection, { PopulateHandlerFn } from '../mixins/database.mixin';
 import { isInGroup } from '../utils';
 import { AuthUserRole, UserAuthMeta } from './api.service';
 
+// Strip security-sensitive keys from user-supplied query before merging
+// with our enforced tenant scope. Mirrors `sanitizeUserQuery` in
+// profile.mixin.ts — caller-controlled `$raw` is especially dangerous
+// because moleculer-knex-filters executes it as raw SQL.
+const TENANT_SCOPE_FORBIDDEN_KEYS = ['$raw', 'tenants'] as const;
+function sanitizeQueryForTenantScope(query: any) {
+  if (!query || typeof query !== 'object') return {};
+  const clean: Record<string, any> = {};
+  for (const key of Object.keys(query)) {
+    if ((TENANT_SCOPE_FORBIDDEN_KEYS as readonly string[]).includes(key)) continue;
+    clean[key] = query[key];
+  }
+  return clean;
+}
+
 export enum UserRole {
   ADMIN = 'ROLE_ADMIN',
   USER = 'ROLE_USER',
@@ -172,12 +187,16 @@ export default class UsersService extends moleculer.Service {
       });
     }
     if (ctx.meta.user && ctx.meta.profile) {
+      // Security $raw clause must be spread LAST so a user-supplied
+      // `query.$raw` cannot replace the tenant scope and read users
+      // outside their tenant.
+      const userQuery = sanitizeQueryForTenantScope(ctx.params.query);
       ctx.params.query = {
+        ...userQuery,
         $raw: {
           condition: `?? \\? ?`,
           bindings: ['tenants', Number(ctx.meta.profile)],
         },
-        ...ctx.params.query,
       };
     } else if (
       !ctx.meta.user &&
@@ -203,9 +222,10 @@ export default class UsersService extends moleculer.Service {
               bindings: ['tenants', ctx.params.filter.tenantId],
             };
           }
+          const adminQuery = sanitizeQueryForTenantScope(ctx.params.query);
           ctx.params.query = {
+            ...adminQuery,
             $raw,
-            ...ctx.params.query,
           };
           delete ctx.params.filter.tenantId;
           delete ctx.params.filter.role;
@@ -298,9 +318,10 @@ export default class UsersService extends moleculer.Service {
       };
     }
 
+    const byTenantQuery = sanitizeQueryForTenantScope(params.query);
     params.query = {
+      ...byTenantQuery,
       $raw,
-      ...params.query,
     };
 
     const rows = await this.findEntities(ctx, params);
@@ -336,9 +357,10 @@ export default class UsersService extends moleculer.Service {
         bindings: ['tenants', ...ids],
       };
 
+      const listQuery = sanitizeQueryForTenantScope(params.query);
       params.query = {
+        ...listQuery,
         $raw,
-        ...params.query,
       };
     }
 
@@ -408,17 +430,22 @@ export default class UsersService extends moleculer.Service {
     const adapter = await this.getAdapter(ctx);
     const table = adapter.getTable();
 
+    // Use parameterized bindings, not string interpolation. Today both
+    // values are validated (enum role, numeric tenant FK), but interpolating
+    // into raw SQL is a time-bomb — anyone wiring a `permissive: true`
+    // path on `tenantUsers.create/update` would turn this into SQL
+    // injection through the `role` string.
     switch (type) {
       case 'create':
       case 'update':
       case 'replace':
-        $set.tenants = table.client.raw(
-          `tenants || '{"${tenantUser.tenant}":"${tenantUser.role}"}'::jsonb`,
-        );
+        $set.tenants = table.client.raw(`tenants || ?::jsonb`, [
+          JSON.stringify({ [String(tenantUser.tenant)]: tenantUser.role }),
+        ]);
         break;
 
       case 'remove':
-        $set.tenants = table.client.raw(`tenants - '${tenantUser.tenant}'`);
+        $set.tenants = table.client.raw(`tenants - ?`, [String(tenantUser.tenant)]);
         break;
     }
 

--- a/services/weightEvents.service.ts
+++ b/services/weightEvents.service.ts
@@ -322,14 +322,27 @@ export default class ToolTypesService extends moleculer.Service {
       path: '/uetk/statistics',
     },
     params: {
+      // Accept either an ISO date string OR an explicit {from, to} window —
+      // never an arbitrary Mongo-style operator object. The previous
+      // signature ran `JSON.parse(date)` on caller input and used the
+      // result as `query.createdAt`, which let an unauthenticated caller
+      // smuggle `{"$ne":null}` / `{"$gt":"…"}` and scrape the full
+      // weight_events dataset by cadastralId. See /cso audit Finding #7.
       date: [
         {
           type: 'string',
           optional: true,
+          // ISO-8601 prefix is enough — Postgres parses the rest.
+          pattern: '^\\d{4}-\\d{2}-\\d{2}',
         },
         {
           type: 'object',
           optional: true,
+          strict: 'remove',
+          props: {
+            from: { type: 'string', pattern: '^\\d{4}-\\d{2}-\\d{2}', optional: true },
+            to: { type: 'string', pattern: '^\\d{4}-\\d{2}-\\d{2}', optional: true },
+          },
         },
       ],
       fish: {
@@ -340,17 +353,21 @@ export default class ToolTypesService extends moleculer.Service {
     },
     auth: RestrictionType.PUBLIC,
   })
-  async getStatisticsForUETK(ctx: Context<{ date: any; fish: number }>) {
+  async getStatisticsForUETK(
+    ctx: Context<{ date: string | { from?: string; to?: string }; fish: number }>,
+  ) {
     const { fish: fishId, date } = ctx.params;
     const query: any = {
       toolsGroup: { $exists: false },
     };
 
-    if (date) {
+    if (typeof date === 'string') {
       query.createdAt = date;
-      try {
-        query.createdAt = JSON.parse(date);
-      } catch (err) {}
+    } else if (date && typeof date === 'object') {
+      const range: Record<string, string> = {};
+      if (date.from) range.$gte = date.from;
+      if (date.to) range.$lte = date.to;
+      if (Object.keys(range).length > 0) query.createdAt = range;
     }
     const events: WeightEvent<'fishing'>[] = await ctx.call('weightEvents.find', {
       query,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3091,6 +3091,11 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+helmet@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-8.1.0.tgz#f96d23fedc89e9476ecb5198181009c804b8b38c"
+  integrity sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==
+
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"


### PR DESCRIPTION
## Summary

Closes the highest-severity issues from a `/cso` security audit run against `main`:

- **Tenant-scope bypass (CRITICAL).** `ProfileMixin.beforeSelect` spread the security filter *before* the user-supplied query, so any USER could send `?query[tenant]=99` and read every entity across tenants (`fishings`, `toolsGroups`, `weightEvents`, `tools`, `tenantUsers`, `fishingEvents`, `toolsGroupsEvents`, `researches`). Reversed the spread and now strip `tenant`/`user`/`$raw` from the caller's query so the security clauses can't be re-injected. Same fix applied in `users.service.ts` `filterTenant`/`byTenant`/`list`.
- **SQL injection time-bomb (HIGH).** `users.service.ts` `tenantUsers.*` event handler interpolated `tenantUser.tenant`/`role` into raw SQL. Validated today but one `permissive: true` call upstream would have turned it into injection through `role`. Switched to parameterised knex bindings.
- **NoSQL operator injection (HIGH).** `weightEvents.getStatisticsForUETK` was PUBLIC and `JSON.parse(date)`-ed caller input straight into `query.createdAt`, letting an unauthenticated attacker send `?date={"$ne":null}` to scrape full weight-events history by cadastralId. Tightened the param schema to either an ISO date string or an explicit `{from, to}` window.
- **MinIO file proxy reading any private object (CRITICAL).** `minio.getFile` was `auth: PUBLIC` and served any object in any bucket via the service's MinIO root credentials — so files uploaded with `isPrivate: true` were trivially leaked. Now requires an authenticated USER. Genuinely public assets (`uploads/fishTypes/*`) keep working via the bucket's existing anonymous S3 policy on direct MinIO URLs.
- **`mappingPolicy: 'all'` auto-exposure (CRITICAL).** Without `rest:` annotations, `minio.removeFile`/`uploadFile`/`fileStat`/`getUrl` were reachable at `/api/minio/<action>` with `auth: DEFAULT`, letting any authenticated USER `POST { path: "<other-user-file>" }` and delete it. Added `rest: null` + `auth: ADMIN` to all four. Internal wrappers (`researches.upload`, `fishTypes.upload`) keep working — they reach minio via `ctx.call`, which bypasses the HTTP auth boundary.
- **Helmet (HIGH).** Added `helmet({ contentSecurityPolicy: false })` — standard security headers (X-Content-Type-Options, Referrer-Policy, HSTS, etc.). CSP intentionally off; this is a JSON API + xlsx export + MinIO proxy, a wrong CSP would break the export response without protecting anything.

## Per the read-only-vs-admin minio model you asked for

- **Read (`minio.getFile`)** → any authenticated USER. Was PUBLIC, now USER.
- **Write/manage (`uploadFile`/`removeFile`/`fileStat`/`getUrl`)** → HTTP surface locked to ADMIN via `rest: null` + `auth: RestrictionType.ADMIN`. Internal `ctx.call` from `researches.upload`/`fishTypes.upload` still works because gateway auth runs only on HTTP boundaries, not on broker calls.

## What did NOT change

- **CORS stays `origin: '*'`** — this API has consumers outside the AplinkosMinisterija orgs and a closed allowlist would silently break unknown clients. Bearer-token auth limits the blast radius (browser doesn't auto-send credentials cross-origin).
- **Internal `ctx.call` flows** to minio actions still work after the HTTP lock-down.
- **`biip-zvejyba-web` does not** pass `tenant`/`user`/`$raw` in any query, doesn't hit `/api/minio/*` directly, and reads public photos through the direct MinIO host URL — none of these fixes alter FE behaviour.

## Test plan

- [ ] `yarn build` clean (verified locally)
- [ ] Smoke-test web QR-login → start fishing → build tools → weigh on shore → end fishing → journal list still loads
- [ ] Smoke-test admin invite (`POST /tenantUsers/invite`) → user appears under tenant
- [ ] Sanity-curl `/zvejyba/api/fishings?query[tenant]=<other_tenant_id>` as a regular USER — must NOT return that tenant's rows
- [ ] Sanity-curl `/zvejyba/api/public/uetk/statistics?date={"$ne":null}` — must reject with a validation error
- [ ] Sanity-curl `/zvejyba/api/minio/<bucket>/<some-private-path>` without auth → 401
- [ ] Verify response carries `X-Content-Type-Options: nosniff` and `Referrer-Policy: no-referrer` headers

## Follow-ups (out of scope)

- SHA-pin GitHub-fork deps in `package.json` (`@moleculer/database`, `biip-auth-nodejs`, `moleculer-knex-filters`, `moleculer-minio`) — supply-chain risk.
- SHA-pin reusable workflows (`@main` → `@<sha>`) in `.github/workflows/deploy-*.yml`.
- `USER node` in Dockerfile final stage.
- Rate-limit on `auth.login`/`evartai.login`/`refreshToken`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)