### PR TITLE
fix(fishings): match populated toolsGroup.id, not the object — unblocks hasUncompletedTools

### DIFF
--- a/services/fishings.service.ts
+++ b/services/fishings.service.ts
@@ -418,7 +418,7 @@ export default class FishTypesService extends moleculer.Service {
       throw new moleculer.Errors.ValidationError('Fishing not started');
     }
     //validate if fishing has unweighted fish
-    const fishWeightEvents: WeightEvent[] = await ctx.call('weightEvents.find', {
+    const fishWeightEvents: WeightEvent<'toolsGroup'>[] = await ctx.call('weightEvents.find', {
       query: {
         fishing: current.id,
       },
@@ -462,7 +462,7 @@ export default class FishTypesService extends moleculer.Service {
   async assertEveryToolTypeHasFishLogged(
     ctx: Context,
     fishing: Fishing,
-    fishWeightEvents: WeightEvent[],
+    fishWeightEvents: WeightEvent<'toolsGroup'>[],
   ) {
     // Ignore Patikrinta events on tools that were later returned — the
     // angler explicitly took the inventory back and that's not the case
@@ -477,8 +477,12 @@ export default class FishTypesService extends moleculer.Service {
         .map((g) => g.id),
     );
 
+    // `weightEvents` defaultPopulates includes `toolsGroup`, so `w.toolsGroup`
+    // is the populated ToolsGroup object — match by `.id` (encoded string),
+    // not by the field itself. Compare CLAUDE.md "Virtual-field populate
+    // gotchas" and the working `getNotCheckedToolsGroups` lookup.
     const hasCheckedActiveTool = fishWeightEvents.some(
-      (w) => w.toolsGroup != null && activeInFishingIds.has(w.toolsGroup),
+      (w) => w.toolsGroup?.id != null && activeInFishingIds.has(w.toolsGroup.id),
     );
     if (!hasCheckedActiveTool) return;
 
@@ -498,7 +502,7 @@ export default class FishTypesService extends moleculer.Service {
   // without a dedicated extra endpoint.
   @Method
   async fishingHasUncompletedTools(ctx: Context, fishing: Fishing): Promise<boolean> {
-    const weights: WeightEvent[] = await ctx.call('weightEvents.find', {
+    const weights: WeightEvent<'toolsGroup'>[] = await ctx.call('weightEvents.find', {
       query: { fishing: fishing.id },
     });
     try {


### PR DESCRIPTION
## TL;DR

PR #126 supaprastino `assertEveryToolTypeHasFishLogged`, bet praleido vieną subtilumą: `weightEvents.find` su default'iniu populate'u grąžina `w.toolsGroup` kaip pilną objektą, ne raw FK. Mano kodas lygina `Set<encoded-string>.has(populatedObject)` — visada false. Rezultatas: `hasUncompletedTools` visada `false`, FE Baigti niekada nedisable'inamas.

## Diagnozė

`weightEvents` service'as turi:
```ts
defaultPopulates: ['toolsGroup', 'geom'],
```

Kai kvieti `ctx.call('weightEvents.find', ...)` be eksplicitiško `populate` parametro, defaultPopulates suveikia → `w.toolsGroup` yra **pilnas ToolsGroup objektas**, ne raw integer FK.

PR #126 kodas:
```ts
const activeInFishingIds = new Set(activeGroups...map((g) => g.id));  // Set<encoded string>

const hasCheckedActiveTool = fishWeightEvents.some(
  (w) => w.toolsGroup != null && activeInFishingIds.has(w.toolsGroup),  // ← BUG
);
```

`activeInFishingIds.has(w.toolsGroup)` → `Set<string>.has(object)` → visada `false`.

→ `hasCheckedActiveTool` visada false → guard'as bailas → `fishingHasUncompletedTools` returns false → `/weights` grąžina `hasUncompletedTools: false` → FE `computeFishingActionGuards` mato `false` → Baigti enabled.

## Working pattern'as iš to paties repo

`toolsGroups.getNotCheckedToolsGroups:544`:
```ts
const groupId = w.toolsGroup?.id;  // ← .id ant populated objekto
```

Tas pats grįžimas — encoded string — kuris match'ina `g.id` iš `toolsGroups.find`. Tai naudoju ir aš dabar.

## Pakeitimas

- `w.toolsGroup` → `w.toolsGroup?.id` lookup'e
- Tipas `WeightEvent[]` → `WeightEvent<'toolsGroup'>[]` abiejose kviečiančiose vietose, kad TS nepraleistų jeigu kažkas ateityje pakeičia `defaultPopulates`

## Susiję

- CLAUDE.md "Virtual-field populate gotchas" sekcija (ta pati šeima)
- PR #126 (kuriame šis bug'as buvo įneštas)

## Test plan

- [ ] Po deploy'o: `curl /weights` (su auth) — kai aktyvus tool'as turi empty Patikrinta event'ą → response turi `hasUncompletedTools: true`
- [ ] FE staging: Baigti mygtukas DISABLE'INAMAS po empty Patikrinta
- [ ] FE staging: po žuvies įrašymo bet kuriame tool'e — Baigti ENABLE'INAMAS
- [ ] BE: `mol $ call fishings.endFishing` su empty Patikrinta → ValidationError
- [ ] BE: po žuvies įrašymo — praeina

🤖 Generated with [Claude Code](https://claude.com/claude-code)