### PR TITLE
fix(fishings): drop buildEvent.fishing filter — catches Patikrinta on stranded tools

### DIFF
--- a/services/fishings.service.ts
+++ b/services/fishings.service.ts
@@ -24,7 +24,6 @@ import { FishType } from './fishTypes.service';
 import { Coordinates, CoordinatesProp, Location } from './location.service';
 import { Polder } from './polders.service';
 import { Tenant } from './tenants.service';
-import { ToolsGroup } from './toolsGroups.service';
 import { User } from './users.service';
 import { GetFishByFishingResponse, WeightEvent } from './weightEvents.service';
 
@@ -451,41 +450,19 @@ export default class FishTypesService extends moleculer.Service {
     return this.updateEntity(ctx, { id: current.id, endEvent: endEvent.id });
   }
 
-  // Refuse end-of-fishing when there's at least one "Patikrinta" event on
-  // an active tool in this fishing but no fish was ever weighed anywhere —
-  // the "Patikrinta" shortcut otherwise lets the user wipe an empty catch
-  // from the journal silently. Scoped fishing-wide, not per (tool type,
-  // location): a single fish payload anywhere in the fishing unblocks
-  // Baigti. The per-bar last-unchecked guard in
-  // `toolsGroups.assertSiblingsHaveFishLogged` still prevents stranding
-  // the catch on individual returns.
+  // Refuse end-of-fishing when this fishing has any weight event but no
+  // fish payload anywhere. The "Patikrinta" shortcut creates an empty
+  // weight event so anglers don't accidentally close out the journal
+  // having logged "checked" but never recording catch. Returned tools'
+  // events still count — see the related PR for the rationale (return
+  // is not a sanctioned escape hatch out of the report).
   @Method
   async assertEveryToolTypeHasFishLogged(
-    ctx: Context,
-    fishing: Fishing,
+    _ctx: Context,
+    _fishing: Fishing,
     fishWeightEvents: WeightEvent<'toolsGroup'>[],
   ) {
-    // Ignore Patikrinta events on tools that were later returned — the
-    // angler explicitly took the inventory back and that's not the case
-    // we want to block.
-    const activeGroups: ToolsGroup<'buildEvent'>[] = await ctx.call('toolsGroups.find', {
-      query: { removeEvent: { $exists: false } },
-      populate: ['buildEvent'],
-    });
-    const activeInFishingIds = new Set(
-      activeGroups
-        .filter((g) => g.buildEvent?.fishing?.id === fishing.id)
-        .map((g) => g.id),
-    );
-
-    // `weightEvents` defaultPopulates includes `toolsGroup`, so `w.toolsGroup`
-    // is the populated ToolsGroup object — match by `.id` (encoded string),
-    // not by the field itself. Compare CLAUDE.md "Virtual-field populate
-    // gotchas" and the working `getNotCheckedToolsGroups` lookup.
-    const hasCheckedActiveTool = fishWeightEvents.some(
-      (w) => w.toolsGroup?.id != null && activeInFishingIds.has(w.toolsGroup.id),
-    );
-    if (!hasCheckedActiveTool) return;
+    if (!fishWeightEvents.length) return;
 
     const hasAnyFishLogged = fishWeightEvents.some(
       (w) => w.data && Object.keys(w.data).length > 0,


### PR DESCRIPTION
## TL;DR

Po PR #126/#127 merge'o staging'e Baigti mygtukas vis tiek likdavo enabled, net kai aktyvus įrankis turėjo empty Patikrinta event'ą. Staging reprodukcija parodė, kad guard'as filtruoja įrankius pagal `buildEvent.fishing.id === current.id` — ir pražiopso įrankius, pastatytus ankstesnėje žvejyboje, bet patikrinamus dabartinėje.

## Staging diagnozė

Su `vadovas@imone.lt` tokenu pataiku konkretų atvejį Kuršių mariose, bare 6:

```
tool_group 591:
  buildEvent.fishing.id = 430  ← built vakar, žvejyba jau baigta
  weightEvent.fishing = 450    ← Patikrinta šiandien (current fishing)
  weightEvent.data = {}        ← empty
```

`/weights` grąžino `hasUncompletedTools: false` — nes guard'as ieškojo tik tų įrankių, kurie BUVO PASTATYTI per dabartinę žvejybą (430 ≠ 450 → praleidžia).

## Sprendimas

Pakeičiu į užkalbį spec'ą, kurį formulavai pats:

> Jei žvejyboje yra bent vienas weight event'as IR niekur neįrašyta žuvis → blokuoti Baigti.

Iš 35 eilučių logikos lieka 5:

```ts
if (!fishWeightEvents.length) return;
const hasAnyFishLogged = fishWeightEvents.some(
  (w) => w.data && Object.keys(w.data).length > 0,
);
if (!hasAnyFishLogged) throw new ValidationError(...);
```

Be `buildEvent.fishing` filtravimo, be `removeEvent` check'o, be active-tools join'o.

## Dėl grąžintų įrankių

Aptarėm — paliekam **be `removeEvent` check'o**. Grąžintų įrankių empty Patikrinta event'ai vis tiek skaitomi:

| Scenario | Blokuoja? |
|---|---|
| Patikrinta empty + įrankis vandeny | TAIP |
| Patikrinta su žuvim → grąžinta | NE (žuvis įrašyta) |
| Patikrinta empty → grąžinta, jokios žuvies | **TAIP** (nėra backdoor'o) |

Escape hatch: užregistruoti žuvį bet kuriame įrankyje (esamame ar naujam) → atblokuoja.

## Test plan

- [ ] BE: `mol $ call fishings.getPreliminaryFishWeight` po empty Patikrinta → `hasUncompletedTools: true`
- [ ] Po žuvies užregistravimo → `hasUncompletedTools: false`
- [ ] FE staging: Baigti DISABLED po empty Patikrinta tame bare 6 (Kuršių marios, vadovas@imone.lt)
- [ ] FE staging: Baigti ENABLED po žuvies užregistravimo
- [ ] BE: `mol $ call fishings.endFishing` su empty Patikrinta → ValidationError
- [ ] Įrankio iš ankstesnės žvejybos Patikrinta → vis tiek blokuoja (regression fix)

## Susiję

- PR #126 (`hasUncompletedTools` flag'as ant `/weights`)
- PR #127 (populated-id mismatch fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)