### PR TITLE
fix(tenants): revert M4 — tenants.remove stays at ADMIN

### DIFF
--- a/services/tenants.service.ts
+++ b/services/tenants.service.ts
@@ -108,11 +108,13 @@ export interface Tenant {
       rest: null,
     },
     update: {},
-    // Tenant deletion is destructive and cascades through tenantUsers,
-    // fishings, weight events, etc. Restrict to SUPER_ADMIN so junior
-    // platform admins can't accidentally soft-delete a paying company
-    // (audit security #M4).
-    remove: { auth: RestrictionType.SUPER_ADMIN },
+    // `tenants.remove` stays at the service-level `auth: ADMIN`.
+    // An earlier hardening pass (PR #129, M4) escalated this to
+    // SUPER_ADMIN, but routine tenant lifecycle (onboarding,
+    // suspension, removal) is admin's daily job through biip-admin-web.
+    // SUPER_ADMIN tier is reserved for platform-level operations
+    // (impersonation, deep auth tools).
+    remove: {},
   },
 })
 export default class TenantsService extends moleculer.Service {

--- a/test/integration/api/security-hardening.spec.ts
+++ b/test/integration/api/security-hardening.spec.ts
@@ -339,11 +339,22 @@ describe('A7 — users.updateMyProfile only writes email/phone', () => {
   });
 });
 
-describe('M4 — tenants.remove is SUPER_ADMIN-only', () => {
-  it('plain ADMIN cannot DELETE /tenants/:id', async () => {
+describe('M4 — tenants.remove stays ADMIN-tier (operational requirement)', () => {
+  // Earlier draft locked this to SUPER_ADMIN; reverted on user feedback —
+  // ROLE_ADMIN operators in biip-admin-web routinely manage tenant
+  // lifecycle (onboarding, suspension, removal). Assert here that a
+  // regular ADMIN auth user CAN still delete, while a USER cannot.
+  it('plain ADMIN CAN DELETE /tenants/:id', async () => {
     const res = await request(apiService.server)
       .delete(`/zvejyba/api/tenants/${apiHelper.tenantB.tenant.id}`)
       .set(apiHelper.getHeaders(apiHelper.adminA.token));
+    expect(res.status).toBe(200);
+  });
+
+  it('USER role cannot DELETE /tenants/:id', async () => {
+    const res = await request(apiService.server)
+      .delete(`/zvejyba/api/tenants/${apiHelper.tenantA.tenant.id}`)
+      .set(apiHelper.getHeaders(apiHelper.ownerA.token, apiHelper.tenantA.tenant.id));
     expect([401, 403]).toContain(res.status);
   });
 });
@@ -366,8 +377,11 @@ describe('H11 — tools.toolsGroup populate uses parameterized $raw', () => {
 
 describe('A8 — partial UNIQUE indices prevent active-row duplicates', () => {
   it('tenant_users (tenant_id, user_id) cannot duplicate', async () => {
+    // Use tenantA — tenantB was just removed by the M4 ADMIN-delete test
+    // above (specs share a broker instance, jest runs describe blocks in
+    // file order). tenantA is the OWNER's home tenant and stays put.
     const fresh = await apiHelper.makeTenantMember(
-      apiHelper.tenantB,
+      apiHelper.tenantA,
       'USER' as any,
     );
     // Try to add the same user again to the same tenant.
@@ -375,7 +389,7 @@ describe('A8 — partial UNIQUE indices prevent active-row duplicates', () => {
       broker.call(
         'tenantUsers.create',
         {
-          tenant: apiHelper.tenantB.tenant.id,
+          tenant: apiHelper.tenantA.tenant.id,
           user: fresh.user.id,
           role: 'USER',
         },


### PR DESCRIPTION
## Summary

Reverts the M4 piece of PR #129 per user feedback: regular ROLE_ADMIN operators in biip-admin-web must keep tenant-deletion rights — that's their daily job (onboarding, suspension, removal). The earlier escalation to SUPER_ADMIN was wrong for this codebase's biznio model.

\`tenants.remove\` returns to the service-level default \`auth: ADMIN\`. USERs are still rejected, verified by a fresh test case. SUPER_ADMIN tier stays reserved for platform-level ops (impersonation, deep auth tools).

## Changes

- \`services/tenants.service.ts\` — drop the action-level \`auth: SUPER_ADMIN\` override on \`remove\`; the leading comment now records why it stays at ADMIN (in case anyone else tries to harden it again).
- \`test/integration/api/security-hardening.spec.ts\`:
  - M4 block: now asserts plain ADMIN **CAN** DELETE; USER still cannot.
  - A8 (UNIQUE indices): switched from \`tenantB\` to \`tenantA\` — the M4 test now actually deletes \`tenantB\`, and the shared broker instance carried that through to A8 (jest runs describe blocks in file order against a shared broker).

## Test plan

- [x] \`yarn build\` — clean
- [x] \`yarn test\` — 167/167 (24 suites)
- [ ] Trigger Deploy to Development from this branch; verify with admin token that DELETE \`/tenants/:id\` returns 200 (currently blocked from dev because the deployed code is from #129).

🤖 Generated with [Claude Code](https://claude.com/claude-code)