### PR TITLE
fix(migrations): no-op A8 unique-index migration — staging recovery

### DIFF
--- a/database/migrations/20260527100000_uniqueConstraintsHardening.js
+++ b/database/migrations/20260527100000_uniqueConstraintsHardening.js
@@ -1,57 +1,32 @@
 /**
- * Defensive UNIQUE constraints, all expressed as PARTIAL unique indices
- * gated on `deleted_at IS NULL` so soft-deleted rows don't collide with
- * fresh ones (audit security #A8 + #M7).
+ * NO-OP.
  *
- * Catches:
- *   - `tenantUsers (tenantId, userId)` — race-induced duplicate
- *     memberships from concurrent `tenantUsers.create`
- *   - `tools (sealNr)` — `validateSealNr` is an app-side check that
- *     loses races with `validateSealNr` running on another node
- *   - `tenants (code)` — duplicate company imports through E-vartai +
- *     `tenants.importBatch`
- *   - `fishings (userId) WHERE end_event_id IS NULL` — guarantees the
- *     single-active-fishing invariant that `startFishing` checks in app
+ * This slot used to add four partial UNIQUE indices (tenant_users,
+ * tools, tenants, fishings) as defense-in-depth against race-induced
+ * duplicates. The original migration ran cleanly on dev but crashed on
+ * staging — staging carries enough history that real duplicates exist
+ * in at least one of those tables, and `CREATE UNIQUE INDEX` against
+ * pre-existing duplicates fails the whole transaction (knex wraps each
+ * migration in `BEGIN…COMMIT`).
  *
- * If this migration fails on an existing duplicate, that's a real data
- * issue — investigate the pair before re-running, don't `--force`.
+ * Knex migration transactions are atomic, so on staging the crash
+ * rolled back every index this file tried to create — knex still sees
+ * this migration as "not yet run". By turning the body into a no-op
+ * we let staging's next boot move past this entry without crashing,
+ * while dev (where the indices DID land) keeps them because dev's
+ * knex_migrations row already says this filename ran.
+ *
+ * The defense-in-depth value is deferred to a follow-up PR that will
+ * (1) audit each table for existing duplicates, (2) decide per pair
+ * whether to soft-delete or keep both, (3) only then add the constraint.
  *
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
-exports.up = async function (knex) {
-  // tenant_users (tenantId, userId) partial unique
-  await knex.raw(`
-    CREATE UNIQUE INDEX IF NOT EXISTS tenant_users_tenant_id_user_id_active_unique
-      ON tenant_users (tenant_id, user_id)
-      WHERE deleted_at IS NULL;
-  `);
-
-  // tools (sealNr) partial unique
-  await knex.raw(`
-    CREATE UNIQUE INDEX IF NOT EXISTS tools_seal_nr_active_unique
-      ON tools (seal_nr)
-      WHERE deleted_at IS NULL;
-  `);
-
-  // tenants (code) partial unique
-  await knex.raw(`
-    CREATE UNIQUE INDEX IF NOT EXISTS tenants_code_active_unique
-      ON tenants (code)
-      WHERE deleted_at IS NULL;
-  `);
-
-  // fishings active-per-user invariant
-  await knex.raw(`
-    CREATE UNIQUE INDEX IF NOT EXISTS fishings_user_id_active_unique
-      ON fishings (user_id)
-      WHERE end_event_id IS NULL AND deleted_at IS NULL;
-  `);
+exports.up = async function (_knex) {
+  // intentionally empty — see header comment
 };
 
-exports.down = async function (knex) {
-  await knex.raw(`DROP INDEX IF EXISTS fishings_user_id_active_unique;`);
-  await knex.raw(`DROP INDEX IF EXISTS tenants_code_active_unique;`);
-  await knex.raw(`DROP INDEX IF EXISTS tools_seal_nr_active_unique;`);
-  await knex.raw(`DROP INDEX IF EXISTS tenant_users_tenant_id_user_id_active_unique;`);
+exports.down = async function (_knex) {
+  // intentionally empty — no schema delta to roll back
 };

--- a/test/integration/api/security-hardening.spec.ts
+++ b/test/integration/api/security-hardening.spec.ts
@@ -375,8 +375,15 @@ describe('H11 — tools.toolsGroup populate uses parameterized $raw', () => {
   });
 });
 
-describe('A8 — partial UNIQUE indices prevent active-row duplicates', () => {
-  it('tenant_users (tenant_id, user_id) cannot duplicate', async () => {
+describe('A8 — tenantUsers app-level dedupe', () => {
+  // The original audit fix tried to enforce this at the DB level with
+  // a partial UNIQUE index, but the migration crashed on staging
+  // (pre-existing historical duplicates). The migration is now a no-op
+  // and the constraint is deferred to a dedicated PR with data
+  // preflight. This test now exercises the existing app-level guard
+  // (`tenantUsers.beforeCreate`), which already throws ALREADY_EXISTS
+  // before reaching the DB.
+  it('duplicate tenantUsers.create is rejected by beforeCreate', async () => {
     // Use tenantA — tenantB was just removed by the M4 ADMIN-delete test
     // above (specs share a broker instance, jest runs describe blocks in
     // file order). tenantA is the OWNER's home tenant and stays put.
@@ -384,7 +391,6 @@ describe('A8 — partial UNIQUE indices prevent active-row duplicates', () => {
       apiHelper.tenantA,
       'USER' as any,
     );
-    // Try to add the same user again to the same tenant.
     await expect(
       broker.call(
         'tenantUsers.create',
@@ -395,7 +401,7 @@ describe('A8 — partial UNIQUE indices prevent active-row duplicates', () => {
         },
         { meta: { authToken: apiHelper.superAdmin.token } },
       ),
-    ).rejects.toBeTruthy();
+    ).rejects.toMatchObject({ type: 'ALREADY_EXISTS' });
   });
 });
 


### PR DESCRIPTION
## Summary

Staging has been failing to start since PR #129 merged (12:48 UTC):

\`\`\`
err: container biip-staging-zvejyba-api-1 is unhealthy
2026/05/27 13:13:43 Process exited with status 1
\`\`\`

Root cause: the A8 migration introduced in PR #129 tried to add four partial UNIQUE indices. Dev came up clean, staging didn't — staging carries enough history that at least one of those tables (\`tenant_users\`, \`tools\`, \`tenants\`, or \`fishings\`) has real duplicates. \`CREATE UNIQUE INDEX\` against pre-existing duplicates fails the whole transaction. Knex wraps each migration in \`BEGIN…COMMIT\`, so on staging the transaction rolled back, the migration was never marked done, and every subsequent boot crashed on the same row.

## Fix

Turn the A8 migration body into a no-op so the boot path moves past this entry. Knex's migration row wasn't committed on staging (transaction rolled back), so the next deploy will run the empty \`up\` and finally mark this filename as run. Dev already had the indices created and the migration recorded; that state is preserved (\`CREATE UNIQUE INDEX IF NOT EXISTS\` semantics, and knex won't re-run a filename it already has).

The defense-in-depth value is deferred to a dedicated PR that will:
1. Audit each affected pair for existing duplicates
2. Decide per-pair whether to soft-delete or keep both
3. THEN create the constraint

The A8 test was also updated to exercise the existing app-level dedupe (\`tenantUsers.beforeCreate\` throws \`ALREADY_EXISTS\`) instead of relying on a constraint that no longer ships.

## Test plan

- [x] Drop the indices on local dev DB (mirror staging state)
- [x] \`yarn build\` — clean
- [x] \`yarn test\` — 167/167 (24 suites)
- [ ] Merge → staging redeploys → \`biip-staging-zvejyba-api-1\` becomes healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)