### PR TITLE
fix(fishings): guard empty tools group in exportCaughtFishes

### DIFF
--- a/services/fishings.service.ts
+++ b/services/fishings.service.ts
@@ -756,8 +756,13 @@ export default class FishTypesService extends moleculer.Service {
       Object.values(fishOnBoat).forEach((toolGroup) => {
         const fishIds = Object.keys(toolGroup.data).map(Number);
 
-        const location = toolGroup.location.name;
-        const tool = toolGroup.toolsGroup.tools[0].toolType.label;
+        const location = toolGroup.location?.name;
+        // A tools group whose tools were all soft-deleted populates to an
+        // empty `tools` array (toolsGroups.tools → tools.find applies the
+        // notDeleted scope, then .filter(Boolean) drops the missing ids), so
+        // tools[0] is undefined. Optional-chain rather than crash the whole
+        // admin export over a single legacy/edited row.
+        const tool = toolGroup.toolsGroup?.tools?.[0]?.toolType?.label;
 
         fishIds.forEach((id) => {
           const fish = fishTypesMap.get(id as any)?.label;
@@ -770,11 +775,11 @@ export default class FishTypesService extends moleculer.Service {
             };
           }
 
-          if (!info[id].locations.includes(location)) {
+          if (location && !info[id].locations.includes(location)) {
             info[id].locations.push(location);
           }
 
-          if (!info[id].tools.includes(tool)) {
+          if (tool && !info[id].tools.includes(tool)) {
             info[id].tools.push(tool);
           }
         });

--- a/test/integration/api/fishings.spec.ts
+++ b/test/integration/api/fishings.spec.ts
@@ -201,3 +201,64 @@ describe('fishings — weighFish payload guards', () => {
     expect(res.body.success).toBe(true);
   });
 });
+
+describe('fishings/exportCaughtFishes — empty tools group (regression)', () => {
+  // Regression for the admin Excel export crashing with
+  // "Cannot read properties of undefined (reading 'toolType')": a boat
+  // tools group whose tools were all soft-deleted populates to an empty
+  // `tools` array, so `tools[0].toolType.label` blew up the whole export.
+  it('exports without crashing when a boat tools group has no live tools', async () => {
+    const ownerMeta = apiHelper.meta(apiHelper.ownerA, apiHelper.tenantA.tenant.id);
+
+    await broker.call('weightEvents.removeAllEntities');
+    await broker.call('fishingEvents.removeAllEntities');
+    await broker.call('fishings.removeAllEntities');
+
+    const fishId = await seedFishType();
+    const toolId = await seedToolForOwner(apiHelper.ownerA, apiHelper.tenantA.tenant.id);
+
+    const tool: any = await broker.call(
+      'tools.get',
+      { id: toolId, populate: ['toolsGroup'] },
+      { meta: ownerMeta },
+    );
+    const toolsGroupId = tool.toolsGroup?.id ?? tool.toolsGroup;
+    expect(toolsGroupId).toBeTruthy();
+
+    await broker.call(
+      'fishings.startFishing',
+      { type: 'INLAND_WATERS', coordinates: sampleCoords },
+      { meta: ownerMeta },
+    );
+
+    const location = {
+      id: '1',
+      name: 'Testas',
+      type: 'INLAND_WATERS',
+      municipality: { id: 1, name: 'Klaipėda' },
+    };
+
+    // Boat (preliminary) catch — carries the tools group.
+    await broker.call(
+      'weightEvents.createWeightEvent',
+      { toolsGroup: toolsGroupId, coordinates: sampleCoords, location, data: { [fishId]: 5 } },
+      { meta: ownerMeta },
+    );
+    // Shore (total) catch — no tools group.
+    await broker.call(
+      'weightEvents.createWeightEvent',
+      { coordinates: sampleCoords, location, data: { [fishId]: 5 } },
+      { meta: ownerMeta },
+    );
+
+    // Soft-delete the only tool → toolsGroup.tools populates to [].
+    await broker.call('tools.remove', { id: toolId }, { meta: ownerMeta });
+
+    const res = await request(apiService.server)
+      .get('/zvejyba/api/fishings/exportCaughtFishes')
+      .set(apiHelper.getHeaders(apiHelper.adminA.token));
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/spreadsheet|octet-stream/);
+  });
+});


### PR DESCRIPTION
## Problema

Admin Excel eksportas `GET /zvejyba/api/fishings/exportCaughtFishes` krito su:

```json
{"name":"TypeError","message":"Cannot read properties of undefined (reading 'toolType')","code":500}
```

Failas neparsisiųsdavo visai.

## Root cause

`services/fishings.service.ts:760` aklai indeksavo:

```ts
const tool = toolGroup.toolsGroup.tools[0].toolType.label;
```

Kai įrankių grupės įrankiai visi **soft-deleted**, `toolsGroups.tools` populate (`services/toolsGroups.service.ts:67-82`) per `tools.find` pritaiko `notDeleted` scope, tada `.filter(Boolean)` išmeta dingusius id → `tools` tampa `[]` → `tools[0]` yra `undefined` → `.toolType` meta `TypeError`.

Eksportas iteruoja per **visas** žvejybas, todėl viena tokia legacy/redaguota grupė nukirsdavo visą atsisiuntimą.

## Fix

Optional-chaining + truthy guard'ai — tuščia grupė praleidžiama, o ne fatal:

```ts
const location = toolGroup.location?.name;
const tool = toolGroup.toolsGroup?.tools?.[0]?.toolType?.label;
// ...
if (location && !info[id].locations.includes(location)) { ... }
if (tool && !info[id].tools.includes(tool)) { ... }
```

## Testas

Pridėtas integracinis regresijos testas (`test/integration/api/fishings.spec.ts`): suseedina boat+shore catch, soft-delete'ina vienintelį įrankį, tikrina kad eksportas grąžina `200` + spreadsheet content-type.

- Be pataisymo testas atkuria **tikslią** klaidą (`TypeError ... reading 'toolType'`) → ✕
- Su pataisymu → ✓

## Verifikacija

- `npx tsc --noEmit` — švarus
- Pilnas suite: **168/168 pass, 24/24 suites**

🤖 Generated with [Claude Code](https://claude.com/claude-code)