### PR TITLE
feat(toolsGroups): block returning previous-fishing tool until fish checked/weighed

### DIFF
--- a/services/toolsGroups.service.ts
+++ b/services/toolsGroups.service.ts
@@ -413,8 +413,9 @@ export default class ToolsGroupsService extends moleculer.Service {
   ) {
     const userId = ctx.meta.user.id;
     const tenantId = ctx.meta.profile;
-    const group: ToolsGroup<'tools'> = await ctx.call('toolsGroups.resolve', {
+    const group: ToolsGroup<'tools' | 'buildEvent'> = await ctx.call('toolsGroups.resolve', {
       id: ctx.params.id,
+      populate: ['tools', 'buildEvent'],
     });
     if (!group) {
       throw new moleculer.Errors.ValidationError('Invalid group');
@@ -425,6 +426,25 @@ export default class ToolsGroupsService extends moleculer.Service {
     const currentFishing: Fishing = await ctx.call('fishings.currentFishing');
     if (!currentFishing) {
       throw new moleculer.Errors.ValidationError('Fishing not started');
+    }
+
+    // A tool deployed in an earlier (already-ended) fishing and left in the
+    // water cannot be pulled back to the warehouse until its catch is recorded
+    // in the CURRENT session — either a "Patikrinta" press or an actual weigh
+    // (both write a weight_event scoped to the current fishing, which
+    // `getFishByToolsGroup` reads). Otherwise the leftover net's catch is
+    // silently lost when the angler returns next trip and removes it without
+    // logging anything. The fishing-id comparison mirrors
+    // `assertSiblingsHaveFishLogged` — `find`/`resolve` return encoded ids, so
+    // a direct `===` against `currentFishing.id` is correct.
+    const builtFishingId = group.buildEvent?.fishing?.id;
+    if (builtFishingId && builtFishingId !== currentFishing.id) {
+      const weighed: WeightEvent = await ctx.call('weightEvents.getFishByToolsGroup', {
+        toolsGroup: ctx.params.id,
+      });
+      if (!weighed) {
+        throw new moleculer.Errors.ValidationError('Previous fishing tool not weighted');
+      }
     }
 
     // Refuse to return the last unchecked tool of a type when every sibling
@@ -640,11 +660,11 @@ export default class ToolsGroupsService extends moleculer.Service {
   @Method
   async assertSiblingsHaveFishLogged(
     ctx: Context,
-    group: ToolsGroup<'tools'>,
+    group: ToolsGroup<'tools' | 'buildEvent'>,
     currentFishing: Fishing,
   ) {
     const toolTypeId = (group.tools?.[0] as Tool<'toolType'> | undefined)?.toolType?.id;
-    const ownLocationId = (group as ToolsGroup<'tools' | 'buildEvent'>).buildEvent?.location?.id;
+    const ownLocationId = group.buildEvent?.location?.id;
     if (!toolTypeId || ownLocationId == null) return;
 
     // Same shape as `getNotCheckedToolsGroups` — `find` returns user-scoped

--- a/test/integration/api/toolsGroups-previous-fishing.spec.ts
+++ b/test/integration/api/toolsGroups-previous-fishing.spec.ts
@@ -1,0 +1,111 @@
+'use strict';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { ServiceBroker } from 'moleculer';
+import request from 'supertest';
+import { ApiHelper, serviceBrokerConfig } from '../../helpers/api';
+
+const broker = new ServiceBroker(serviceBrokerConfig);
+const apiHelper = new ApiHelper(broker);
+const apiService = apiHelper.initializeServices();
+
+const sampleCoords = { x: 21.13, y: 55.71 };
+const sampleLocation = {
+  id: '00070001',
+  name: 'Kuršių marios',
+  type: 'ESTUARY',
+  municipality: { id: 41, name: 'Klaipėda' },
+};
+
+let ownerMeta: any;
+let headers: Record<string, string>;
+// The tool deployed in the first (now-ended) fishing and never pulled out.
+let leftoverGroupId: number;
+
+// Scenario: a net is built in fishing #1, the angler ends the trip WITHOUT
+// weighing or pulling it out, then starts fishing #2 the next day and tries
+// to return the leftover net straight to the warehouse. The catch would be
+// lost — so `removeTools` must block until the fish is checked/weighed in the
+// current session.
+beforeAll(async () => {
+  await broker.start();
+  await apiHelper.setup();
+  ownerMeta = apiHelper.meta(apiHelper.ownerA, apiHelper.tenantA.tenant.id);
+  headers = apiHelper.getHeaders(apiHelper.ownerA.token, apiHelper.tenantA.tenant.id);
+
+  const toolTypes: any[] = await broker.call('toolTypes.find');
+  const sealNr = 'S-PREV-1';
+  await broker.call(
+    'tools.create',
+    { sealNr, toolType: toolTypes[0].id, data: { eyeSize: 60, netLength: 30 } },
+    { meta: ownerMeta },
+  );
+
+  // Fishing #1 — build the net, then end the trip with no weights logged.
+  await broker.call(
+    'fishings.startFishing',
+    { type: 'ESTUARY', coordinates: sampleCoords },
+    { meta: ownerMeta },
+  );
+  const groups: any[] = await broker.call(
+    'toolsGroups.find',
+    { query: { removeEvent: { $exists: false } } },
+    { meta: ownerMeta },
+  );
+  leftoverGroupId = groups[0].id;
+  await request(apiService.server)
+    .post(`/zvejyba/api/toolsGroups/build/${leftoverGroupId}`)
+    .set(headers)
+    .send({ coordinates: sampleCoords, location: sampleLocation })
+    .expect(200);
+  // No weight events at all → endFishing is allowed and the net stays in the water.
+  await broker.call('fishings.endFishing', { coordinates: sampleCoords }, { meta: ownerMeta });
+
+  // Fishing #2 — fresh trip, the leftover net is still deployed.
+  await broker.call(
+    'fishings.startFishing',
+    { type: 'ESTUARY', coordinates: sampleCoords },
+    { meta: ownerMeta },
+  );
+});
+afterAll(() => broker.stop());
+
+describe('toolsGroups.removeTools — leftover tool from a previous fishing', () => {
+  it('rejects returning a previous-fishing tool before its fish is checked/weighed', async () => {
+    const res = await request(apiService.server)
+      .post(`/zvejyba/api/toolsGroups/remove/${leftoverGroupId}`)
+      .set(headers)
+      .send({ coordinates: sampleCoords, location: sampleLocation });
+    expect(res.status).toBe(422);
+    expect(res.body.message).toBe('Previous fishing tool not weighted');
+    // Still deployed — the remove must not have gone through.
+    const group: any = await broker.call(
+      'toolsGroups.resolve',
+      { id: leftoverGroupId },
+      { meta: ownerMeta },
+    );
+    expect(group.removeEvent).toBeFalsy();
+  });
+
+  it('allows the return once the tool is checked ("Patikrinta", empty weight) this session', async () => {
+    // An empty check writes a weight_event with `data: {}` scoped to the
+    // current fishing — per spec, checking OR weighing unblocks the return.
+    await request(apiService.server)
+      .post(`/zvejyba/api/toolsGroups/weigh/${leftoverGroupId}`)
+      .set(headers)
+      .send({ coordinates: sampleCoords, location: sampleLocation, data: {} })
+      .expect(200);
+
+    await request(apiService.server)
+      .post(`/zvejyba/api/toolsGroups/remove/${leftoverGroupId}`)
+      .set(headers)
+      .send({ coordinates: sampleCoords, location: sampleLocation })
+      .expect(200);
+
+    const group: any = await broker.call(
+      'toolsGroups.resolve',
+      { id: leftoverGroupId },
+      { meta: ownerMeta },
+    );
+    expect(group.removeEvent).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Problem

A net deployed in a fishing that then **ends without the tool being pulled out** stays in the water. On the next trip the angler could return that leftover tool straight to the warehouse via `POST /toolsGroups/remove/:id` — **silently losing the catch** that net may hold, since nothing forced a check/weigh first.

The existing `assertSiblingsHaveFishLogged` guard only covers the *same-fishing*, same-bar/type return path. Nothing covered a tool carried over from a **previous (already-ended) fishing**.

## Change

`removeTools` now, for a tool whose `buildEvent.fishing.id` differs from the current fishing, requires a **current-session** `weight_event` for that tools group before allowing `REMOVE_TOOLS`:

- A **"Patikrinta" check** (empty `data: {}`) **or** an actual **weigh** both satisfy it — matching the product rule *"patikrinti **arba** pasverti"*.
- The check/weigh must happen **in the current session** (re-uses `weightEvents.getFishByToolsGroup`, which is scoped to the current fishing) — a check recorded in the old fishing does not count.
- Legacy rows with no `buildEvent.fishing` are skipped (no false block).
- Fishing-id comparison follows the existing `assertSiblingsHaveFishLogged` pattern (resolve/find return encoded ids, so a direct `===` is correct).

On block it throws `ValidationError('Previous fishing tool not weighted')`, which the web maps to a Lithuanian toast (see paired web PR).

## Tests

New `test/integration/api/toolsGroups-previous-fishing.spec.ts` (self-contained broker):
1. Build a net in fishing #1 → end the trip with no weights → start fishing #2 → `remove` is rejected **422 `Previous fishing tool not weighted`**, tool stays deployed.
2. Record an empty **"Patikrinta"** this session → `remove` now succeeds **200**, `removeEvent` set.

Verification:
- ✅ `tsc --noEmit` clean
- ✅ new spec passes (2/2)
- ✅ existing `toolsGroups`, `toolsGroups-connect`, `weightEvents` specs pass (18/18) — no regression
- ✅ eslint clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)