### PR TITLE
feat(toolsGroups): require check/weigh before returning any tool to warehouse

### DIFF
--- a/services/toolsGroups.service.ts
+++ b/services/toolsGroups.service.ts
@@ -428,23 +428,17 @@ export default class ToolsGroupsService extends moleculer.Service {
       throw new moleculer.Errors.ValidationError('Fishing not started');
     }
 
-    // A tool deployed in an earlier (already-ended) fishing and left in the
-    // water cannot be pulled back to the warehouse until its catch is recorded
-    // in the CURRENT session — either a "Patikrinta" press or an actual weigh
-    // (both write a weight_event scoped to the current fishing, which
-    // `getFishByToolsGroup` reads). Otherwise the leftover net's catch is
-    // silently lost when the angler returns next trip and removes it without
-    // logging anything. The fishing-id comparison mirrors
-    // `assertSiblingsHaveFishLogged` — `find`/`resolve` return encoded ids, so
-    // a direct `===` against `currentFishing.id` is correct.
-    const builtFishingId = group.buildEvent?.fishing?.id;
-    if (builtFishingId && builtFishingId !== currentFishing.id) {
-      const weighed: WeightEvent = await ctx.call('weightEvents.getFishByToolsGroup', {
-        toolsGroup: ctx.params.id,
-      });
-      if (!weighed) {
-        throw new moleculer.Errors.ValidationError('Previous fishing tool not weighted');
-      }
+    // Every tool must be checked ("Patikrinta") or weighed before it can be
+    // pulled back to the warehouse — both write a weight_event scoped to the
+    // current session, which `getFishByToolsGroup` reads. This holds whether
+    // the net was set this trip or an earlier, already-ended one: returning it
+    // unchecked silently loses the catch. (Originally only the previous-fishing
+    // leftover case was guarded; the rule now applies to in-session tools too.)
+    const weighed: WeightEvent = await ctx.call('weightEvents.getFishByToolsGroup', {
+      toolsGroup: ctx.params.id,
+    });
+    if (!weighed) {
+      throw new moleculer.Errors.ValidationError('Previous fishing tool not weighted');
     }
 
     // Refuse to return the last unchecked tool of a type when every sibling

--- a/test/integration/api/toolsGroups-return-requires-check.spec.ts
+++ b/test/integration/api/toolsGroups-return-requires-check.spec.ts
@@ -1,0 +1,96 @@
+'use strict';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { ServiceBroker } from 'moleculer';
+import request from 'supertest';
+import { ApiHelper, serviceBrokerConfig } from '../../helpers/api';
+
+const broker = new ServiceBroker(serviceBrokerConfig);
+const apiHelper = new ApiHelper(broker);
+const apiService = apiHelper.initializeServices();
+
+const sampleCoords = { x: 21.13, y: 55.71 };
+const sampleLocation = {
+  id: '00070001',
+  name: 'Kuršių marios',
+  type: 'ESTUARY',
+  municipality: { id: 41, name: 'Klaipėda' },
+};
+
+let ownerMeta: any;
+let headers: Record<string, string>;
+// A net built during the CURRENT fishing and not yet checked/weighed.
+let groupId: number;
+
+// Scenario: within a single, still-running fishing the angler builds a net and
+// immediately tries to return it to the warehouse without pressing "Patikrinta"
+// or weighing. The catch (if any) would be lost — so `removeTools` must block
+// in-session tools too, not only leftovers from a previous trip.
+beforeAll(async () => {
+  await broker.start();
+  await apiHelper.setup();
+  ownerMeta = apiHelper.meta(apiHelper.ownerA, apiHelper.tenantA.tenant.id);
+  headers = apiHelper.getHeaders(apiHelper.ownerA.token, apiHelper.tenantA.tenant.id);
+
+  const toolTypes: any[] = await broker.call('toolTypes.find');
+  await broker.call(
+    'tools.create',
+    { sealNr: 'S-CUR-1', toolType: toolTypes[0].id, data: { eyeSize: 60, netLength: 30 } },
+    { meta: ownerMeta },
+  );
+
+  await broker.call(
+    'fishings.startFishing',
+    { type: 'ESTUARY', coordinates: sampleCoords },
+    { meta: ownerMeta },
+  );
+  const groups: any[] = await broker.call(
+    'toolsGroups.find',
+    { query: { removeEvent: { $exists: false } } },
+    { meta: ownerMeta },
+  );
+  groupId = groups[0].id;
+  await request(apiService.server)
+    .post(`/zvejyba/api/toolsGroups/build/${groupId}`)
+    .set(headers)
+    .send({ coordinates: sampleCoords, location: sampleLocation })
+    .expect(200);
+});
+afterAll(() => broker.stop());
+
+describe('toolsGroups.removeTools — tool built in the current fishing', () => {
+  it('rejects returning an in-session tool before it is checked/weighed', async () => {
+    const res = await request(apiService.server)
+      .post(`/zvejyba/api/toolsGroups/remove/${groupId}`)
+      .set(headers)
+      .send({ coordinates: sampleCoords, location: sampleLocation });
+    expect(res.status).toBe(422);
+    expect(res.body.message).toBe('Previous fishing tool not weighted');
+    const group: any = await broker.call(
+      'toolsGroups.resolve',
+      { id: groupId },
+      { meta: ownerMeta },
+    );
+    expect(group.removeEvent).toBeFalsy();
+  });
+
+  it('allows the return once the tool is checked ("Patikrinta", empty weight)', async () => {
+    await request(apiService.server)
+      .post(`/zvejyba/api/toolsGroups/weigh/${groupId}`)
+      .set(headers)
+      .send({ coordinates: sampleCoords, location: sampleLocation, data: {} })
+      .expect(200);
+
+    await request(apiService.server)
+      .post(`/zvejyba/api/toolsGroups/remove/${groupId}`)
+      .set(headers)
+      .send({ coordinates: sampleCoords, location: sampleLocation })
+      .expect(200);
+
+    const group: any = await broker.call(
+      'toolsGroups.resolve',
+      { id: groupId },
+      { meta: ownerMeta },
+    );
+    expect(group.removeEvent).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Problema

Įrankį, įmerktą į vandenį, žvejys gali grąžinti į sandėlį („Sugrąžinti į sandėlį") — bet jei jis nebuvo **patikrintas** („Patikrinta") arba **pasvertas**, sugautas laimikis tyliai prarandamas. Iki šiol serveris to reikalavo **tik** praėjusios (jau užbaigtos) žvejybos paliktiems įrankiams; tos pačios žvejybos metu pastatytą įrankį buvo galima grąžinti neįtikrintą.

## Sprendimas

`toolsGroups.removeTools` guard'as apibendrintas: **kiekvienas** grąžinamas įrankis privalo turėti šios sesijos weight event'ą (patikrintas arba pasvertas), nepriklausomai nuo to, kurioje žvejyboje jis pastatytas. `getFishByToolsGroup` skaito tiek „Patikrinta" (`data: {}`), tiek tikrą pasvėrimą.

Žvejys niekada neįstringa: neįtikrintas įrankis FE pusėje visada turi sverti/„Patikrinta" mygtukus (`showWeightButtons = !isCheckedTool`), tad srautas: pastatė → patikrino/pasvėrė → atsiranda „Sugrąžinti į sandėlį".

FE pusė (mygtuko slėpimas + toast): AplinkosMinisterija/biip-zvejyba-web#157.

## Pakeitimai

- `services/toolsGroups.service.ts` — `removeTools`: weight-event reikalavimas iš previous-fishing-only tapo besąlyginis.
- `test/integration/api/toolsGroups-return-requires-check.spec.ts` — naujas integ. testas šios žvejybos atvejui (esamas `toolsGroups-previous-fishing.spec.ts` dengia paliktus įrankius).

## Patikrinta

- `tsc --build` — švarus
- `eslint` — švarus
- Integ. testai: `toolsGroups-previous-fishing` + `toolsGroups-return-requires-check` → **4 passed** (regresijos nėra, naujas elgesys veikia)

🤖 Generated with [Claude Code](https://claude.com/claude-code)