### PR TITLE
feat(fishings): journal filter backend — member filter + location options

### DIFF
--- a/services/fishings.service.ts
+++ b/services/fishings.service.ts
@@ -536,13 +536,15 @@ export default class FishTypesService extends moleculer.Service {
     return ctx;
   }
 
-  // Accept only a bare scalar id (number or short plain string). An object or
-  // array is the only way to smuggle a Mongo operator / `$raw` through the
-  // `user` value, so anything non-scalar is rejected (the filter is skipped).
+  // Accept only a single bare scalar id. An object/array is the only way to
+  // smuggle a Mongo operator / `$raw` through the `user` value, and a
+  // comma-list string would be expanded into an IN(...) by moleculer-knex-
+  // filters — so we restrict strings to one alphanumeric token (covers both
+  // raw integer ids and secure-encoded ids) and reject everything else.
   @Method
   scalarMemberId(value: unknown): number | string | null {
     if (typeof value === 'number' && Number.isFinite(value)) return value;
-    if (typeof value === 'string' && value.length > 0 && value.length <= 40) return value;
+    if (typeof value === 'string' && /^[A-Za-z0-9]{1,40}$/.test(value)) return value;
     return null;
   }
 

--- a/services/fishings.service.ts
+++ b/services/fishings.service.ts
@@ -396,7 +396,17 @@ export default class FishTypesService extends moleculer.Service {
       ctx.params.uetkCadastralId = '00070001'; // Kuršių marios
     }
 
-    return this.createEntity(ctx, { ...ctx.params, startEvent: startEvent.id });
+    const fishing = await this.createEntity(ctx, { ...ctx.params, startEvent: startEvent.id });
+
+    // A new fishing may add a location → drop the cached `fishingLocations`
+    // options for the views that include it (admin's all-list + the creator's
+    // own scope). Other tenants' caches stay valid.
+    await this.broker.cacher?.del([
+      'fishings.locations:admin',
+      `fishings.locations:${this.fishingLocationsScope(ctx)}`,
+    ]);
+
+    return fishing;
   }
 
   @Action({
@@ -561,6 +571,16 @@ export default class FishTypesService extends moleculer.Service {
     auth: RestrictionType.DEFAULT,
   })
   async fishingLocations(ctx: Context<unknown, UserAuthMeta>) {
+    // Per-scope cache: the result differs by caller (admin → all, company →
+    // its tenant, freelancer → own), so the key MUST carry the scope or one
+    // tenant would read another's cached list. Built explicitly (not
+    // declarative `#meta` keys) so the scope is provably in the key. Saves the
+    // distinct query + the external UETK resolve on repeat opens and on the
+    // async-select's per-keystroke option fetches. Invalidated on startFishing.
+    const cacheKey = `fishings.locations:${this.fishingLocationsScope(ctx)}`;
+    const cached = await this.broker.cacher?.get(cacheKey);
+    if (cached) return cached;
+
     const fishings: Array<{ uetkCadastralId?: string; polderId?: number }> = await ctx.call(
       'fishings.find',
       { query: {}, fields: ['uetkCadastralId', 'polderId'] },
@@ -594,7 +614,24 @@ export default class FishTypesService extends moleculer.Service {
       ...polders.map((p) => ({ id: p.id, name: p.name, polder: true })),
     ];
     options.sort((a, b) => (a.name || '').localeCompare(b.name || '', 'lt'));
+    await this.broker.cacher?.set(cacheKey, options, 60 * 60);
     return options;
+  }
+
+  // Cache-key scope for `fishingLocations`, mirroring how `fishings.find`
+  // scopes the rows: admins share one "all" entry; tenant members share their
+  // tenant's; a freelancer keys on their own user. Derived from trusted
+  // `ctx.meta`, so a caller can never craft it to read another scope's cache.
+  @Method
+  fishingLocationsScope(ctx: Context<unknown, UserAuthMeta>): string {
+    const meta = ctx.meta;
+    const isAdmin = [AuthUserRole.ADMIN, AuthUserRole.SUPER_ADMIN].some(
+      (role) => role === meta?.authUser?.type,
+    );
+    if (isAdmin) return 'admin';
+    if (meta?.profile && meta?.user) return `t:${meta.profile}`;
+    if (meta?.user) return `u:${meta.user.id}`;
+    return 'anon';
   }
 
   @Action({

--- a/services/fishings.service.ts
+++ b/services/fishings.service.ts
@@ -18,7 +18,7 @@ import {
 
 import ProfileMixin from '../mixins/profile.mixin';
 import { coordinatesToGeometry, geomToWgs } from '../modules/geometry';
-import { UserAuthMeta } from './api.service';
+import { AuthUserRole, UserAuthMeta } from './api.service';
 import { FishingEvent, FishingEventType } from './fishingEvents.service';
 import { FishType } from './fishTypes.service';
 import { Coordinates, CoordinatesProp, Location } from './location.service';
@@ -292,11 +292,11 @@ export type Fishing<
       startFishing: ['beforeCreate'],
       skipFishing: ['beforeCreate'],
       currentFishing: ['beforeSelect'],
-      list: ['beforeSelect'],
-      find: ['beforeSelect'],
-      count: ['beforeSelect'],
+      list: ['beforeJournalSelect'],
+      find: ['beforeJournalSelect'],
+      count: ['beforeJournalSelect'],
       get: ['beforeSelect'],
-      all: ['beforeSelect'],
+      all: ['beforeJournalSelect'],
     },
   },
 })
@@ -507,6 +507,43 @@ export default class FishTypesService extends moleculer.Service {
     } catch {
       return true;
     }
+  }
+
+  // Journal-list scoping. ProfileMixin.beforeSelect strips `user` from caller
+  // queries (a FORBIDDEN key) to block horizontal escalation. For the fishing
+  // journal a company (tenant-profile) member is allowed to narrow the
+  // *already tenant-scoped* list to one colleague, so we re-apply `user` AFTER
+  // the shared scoping — only for tenant profiles, only as a bare scalar, and
+  // with `tenant: profile` still enforced. This exposes nothing new (every
+  // tenant member can already read the whole tenant journal) and can never
+  // cross tenants. Admins keep their unrestricted `query.user` (the mixin
+  // doesn't scope them); personal profiles keep `user` stripped (forced to
+  // self) — see security-regression spec.
+  @Method
+  beforeJournalSelect(ctx: Context<{ query?: { user?: unknown } }, UserAuthMeta>) {
+    const requestedMember = this.scalarMemberId(ctx.params?.query?.user);
+
+    this.beforeSelect(ctx);
+
+    const meta = ctx.meta;
+    const isAdmin = [AuthUserRole.ADMIN, AuthUserRole.SUPER_ADMIN].some(
+      (role) => role === meta?.authUser?.type,
+    );
+    const isTenantProfile = !!meta?.profile && !!meta?.user;
+    if (!isAdmin && isTenantProfile && requestedMember != null) {
+      ctx.params.query = { ...ctx.params.query, user: requestedMember };
+    }
+    return ctx;
+  }
+
+  // Accept only a bare scalar id (number or short plain string). An object or
+  // array is the only way to smuggle a Mongo operator / `$raw` through the
+  // `user` value, so anything non-scalar is rejected (the filter is skipped).
+  @Method
+  scalarMemberId(value: unknown): number | string | null {
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+    if (typeof value === 'string' && value.length > 0 && value.length <= 40) return value;
+    return null;
   }
 
   @Action({

--- a/services/fishings.service.ts
+++ b/services/fishings.service.ts
@@ -548,6 +548,55 @@ export default class FishTypesService extends moleculer.Service {
     return null;
   }
 
+  // Distinct locations that appear in the caller's fishings — options for the
+  // journal "location" filter. Scope is whatever `fishings.find` applies to
+  // the caller (admin → all, company → its tenant, freelancer → own), so the
+  // dropdown only lists places actually fished. Names are resolved the same
+  // way as the `location` virtual field; the external UETK lookup is wrapped
+  // defensively so a slow/down UETK degrades to "polders only" instead of
+  // breaking the whole filter. Each option carries `polder` so the client
+  // knows whether the selection filters `polderId` or `uetkCadastralId`.
+  @Action({
+    rest: 'GET /locations',
+    auth: RestrictionType.DEFAULT,
+  })
+  async fishingLocations(ctx: Context<unknown, UserAuthMeta>) {
+    const fishings: Array<{ uetkCadastralId?: string; polderId?: number }> = await ctx.call(
+      'fishings.find',
+      { query: {}, fields: ['uetkCadastralId', 'polderId'] },
+    );
+
+    const cadastralIds = Array.from(
+      new Set(fishings.map((f) => f.uetkCadastralId).filter((id): id is string => !!id)),
+    );
+    const polderIds = Array.from(
+      new Set(fishings.map((f) => f.polderId).filter((id): id is number => id != null)),
+    );
+
+    let waterBodies: Array<{ id: string; name: string }> = [];
+    if (cadastralIds.length) {
+      try {
+        waterBodies = await ctx.call('locations.uetkSearchByCadastralId', {
+          cadastralId: cadastralIds,
+        });
+      } catch (err: any) {
+        this.logger.warn(`[fishingLocations] UETK lookup failed: ${err?.message}`);
+      }
+    }
+    const polders: Polder[] = polderIds.length
+      ? await ctx.call('polders.find', { query: { id: { $in: polderIds } } })
+      : [];
+
+    const options = [
+      ...(waterBodies || [])
+        .filter((l) => !!l)
+        .map((l) => ({ id: l.id, name: l.name, polder: false })),
+      ...polders.map((p) => ({ id: p.id, name: p.name, polder: true })),
+    ];
+    options.sort((a, b) => (a.name || '').localeCompare(b.name || '', 'lt'));
+    return options;
+  }
+
   @Action({
     rest: 'GET /current',
     auth: RestrictionType.USER,

--- a/test/integration/api/fishings-location-options.spec.ts
+++ b/test/integration/api/fishings-location-options.spec.ts
@@ -1,0 +1,77 @@
+'use strict';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { ServiceBroker } from 'moleculer';
+import { ApiHelper, serviceBrokerConfig } from '../../helpers/api';
+
+// `fishings.fishingLocations` powers the journal "location" filter: the
+// distinct places the caller actually fished, scoped like the journal itself
+// (admin → all, company → its tenant, freelancer → own). Tested with POLDERS
+// fishings only — polders resolve from the local table, so no external UETK
+// call is needed (that branch is defensively wrapped anyway).
+const broker = new ServiceBroker(serviceBrokerConfig);
+const apiHelper = new ApiHelper(broker);
+apiHelper.initializeServices();
+
+let polderAId: number;
+let polderBId: number;
+
+beforeAll(async () => {
+  await broker.start();
+  await apiHelper.setup();
+
+  const polders: any[] = await broker.call('polders.find');
+  polderAId = polders[0].id;
+  polderBId = polders[1].id;
+
+  const adminMeta = { authToken: apiHelper.superAdmin.token };
+  await broker.call(
+    'fishings.create',
+    { type: 'POLDERS', tenant: apiHelper.tenantA.tenant.id, user: apiHelper.ownerA.user.id, polderId: polderAId },
+    { meta: adminMeta },
+  );
+  await broker.call(
+    'fishings.create',
+    { type: 'POLDERS', tenant: apiHelper.tenantB.tenant.id, user: apiHelper.ownerB.user.id, polderId: polderBId },
+    { meta: adminMeta },
+  );
+});
+afterAll(() => broker.stop());
+
+const polderIds = (res: any[]) => res.filter((o) => o.polder).map((o) => o.id);
+
+describe('fishings.fishingLocations — journal location options', () => {
+  it('a company sees only the locations its own tenant fished', async () => {
+    const res: any[] = await broker.call(
+      'fishings.fishingLocations',
+      {},
+      { meta: apiHelper.meta(apiHelper.ownerA, apiHelper.tenantA.tenant.id) },
+    );
+    const ids = polderIds(res);
+    expect(ids).toContain(polderAId);
+    expect(ids).not.toContain(polderBId); // never another tenant's location
+    // Options carry a name + a `polder` discriminator for the client.
+    const opt = res.find((o) => o.id === polderAId);
+    expect(opt).toMatchObject({ polder: true });
+    expect(typeof opt.name).toBe('string');
+  });
+
+  it('an admin sees locations across all tenants', async () => {
+    const res: any[] = await broker.call(
+      'fishings.fishingLocations',
+      {},
+      { meta: apiHelper.meta(apiHelper.superAdmin) },
+    );
+    const ids = polderIds(res);
+    expect(ids).toContain(polderAId);
+    expect(ids).toContain(polderBId);
+  });
+
+  it('a freelancer with no fishings gets an empty list', async () => {
+    const res: any[] = await broker.call(
+      'fishings.fishingLocations',
+      {},
+      { meta: apiHelper.meta(apiHelper.freelancerA) },
+    );
+    expect(res).toEqual([]);
+  });
+});

--- a/test/integration/api/fishings-location-options.spec.ts
+++ b/test/integration/api/fishings-location-options.spec.ts
@@ -74,4 +74,29 @@ describe('fishings.fishingLocations — journal location options', () => {
     );
     expect(res).toEqual([]);
   });
+
+  it('starting a fishing invalidates the cached options for that scope', async () => {
+    const ownerMeta = apiHelper.meta(apiHelper.ownerA, apiHelper.tenantA.tenant.id);
+    const cacheKey = `fishings.locations:t:${apiHelper.tenantA.tenant.id}`;
+
+    // Prime the cache for this scope.
+    await broker.call('fishings.fishingLocations', {}, { meta: ownerMeta });
+    expect(await broker.cacher!.get(cacheKey)).toBeTruthy();
+
+    // A new fishing must drop the entry (proves the `cacher.del([...])` call
+    // actually fires and removes the right keys — not just a no-op).
+    const toolTypes: any[] = await broker.call('toolTypes.find');
+    await broker.call(
+      'tools.create',
+      { sealNr: 'S-INV-1', toolType: toolTypes[0].id, data: { eyeSize: 60, netLength: 30 } },
+      { meta: ownerMeta },
+    );
+    await broker.call(
+      'fishings.startFishing',
+      { type: 'POLDERS', coordinates: { x: 21.13, y: 55.71 }, polderId: polderAId },
+      { meta: ownerMeta },
+    );
+
+    expect(await broker.cacher!.get(cacheKey)).toBeFalsy();
+  });
 });

--- a/test/integration/api/fishings-member-filter.spec.ts
+++ b/test/integration/api/fishings-member-filter.spec.ts
@@ -58,6 +58,28 @@ describe('fishings journal — company member filter', () => {
     expect(ids).toContain(userAFishingId); // colleague's fishing shows
     expect(ids).not.toContain(ownerAFishingId); // own fishing filtered out
     expect(ids).not.toContain(ownerBFishingId); // never another tenant
+    // The paginated total must reflect the member filter too (only userA's
+    // single tenantA fishing), not the whole tenant journal.
+    expect(res.body.total).toBe(1);
+  });
+
+  it('a comma-list user value is rejected (no IN-expansion), stays tenant-scoped', async () => {
+    const res = await request(apiService.server)
+      .get('/zvejyba/api/fishings')
+      .set(apiHelper.getHeaders(apiHelper.ownerA.token, apiHelper.tenantA.tenant.id))
+      .query({
+        query: JSON.stringify({
+          user: `${apiHelper.userA.user.id},${apiHelper.ownerB.user.id}`,
+        }),
+      })
+      .expect(200);
+
+    const ids = idsOf(res);
+    // Rejected → no member narrowing → full tenantA journal (userA + ownerA),
+    // and crucially no tenantB leak via a smuggled IN(...) list.
+    expect(ids).toContain(userAFishingId);
+    expect(ids).toContain(ownerAFishingId);
+    expect(ids).not.toContain(ownerBFishingId);
   });
 
   it('the member filter can never cross tenants', async () => {

--- a/test/integration/api/fishings-member-filter.spec.ts
+++ b/test/integration/api/fishings-member-filter.spec.ts
@@ -1,0 +1,111 @@
+'use strict';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { ServiceBroker } from 'moleculer';
+import request from 'supertest';
+import { ApiHelper, serviceBrokerConfig } from '../../helpers/api';
+
+// A company (tenant-profile) member may narrow the already tenant-scoped
+// fishing journal to one colleague (`?query={"user":<id>}`). ProfileMixin
+// normally strips `user` from caller queries; fishings re-applies it for
+// tenant profiles only, as a bare scalar, with `tenant: profile` still
+// enforced. These specs pin the allowed behaviour AND the security envelope:
+// it can never cross tenants and an object/operator value is ignored.
+const broker = new ServiceBroker(serviceBrokerConfig);
+const apiHelper = new ApiHelper(broker);
+const apiService = apiHelper.initializeServices();
+
+let userAFishingId: any;
+let ownerAFishingId: any;
+let ownerBFishingId: any;
+
+beforeAll(async () => {
+  await broker.start();
+  await apiHelper.setup();
+
+  const adminMeta = { authToken: apiHelper.superAdmin.token };
+  const userAFishing: any = await broker.call(
+    'fishings.create',
+    { type: 'INLAND_WATERS', tenant: apiHelper.tenantA.tenant.id, user: apiHelper.userA.user.id },
+    { meta: adminMeta },
+  );
+  userAFishingId = userAFishing.id;
+  const ownerAFishing: any = await broker.call(
+    'fishings.create',
+    { type: 'INLAND_WATERS', tenant: apiHelper.tenantA.tenant.id, user: apiHelper.ownerA.user.id },
+    { meta: adminMeta },
+  );
+  ownerAFishingId = ownerAFishing.id;
+  const ownerBFishing: any = await broker.call(
+    'fishings.create',
+    { type: 'INLAND_WATERS', tenant: apiHelper.tenantB.tenant.id, user: apiHelper.ownerB.user.id },
+    { meta: adminMeta },
+  );
+  ownerBFishingId = ownerBFishing.id;
+});
+afterAll(() => broker.stop());
+
+const idsOf = (res: any) => (res.body.rows ?? []).map((r: any) => r.id);
+
+describe('fishings journal — company member filter', () => {
+  it('a tenant member can narrow the journal to a colleague', async () => {
+    const res = await request(apiService.server)
+      .get('/zvejyba/api/fishings')
+      .set(apiHelper.getHeaders(apiHelper.ownerA.token, apiHelper.tenantA.tenant.id))
+      .query({ query: JSON.stringify({ user: apiHelper.userA.user.id }) })
+      .expect(200);
+
+    const ids = idsOf(res);
+    expect(ids).toContain(userAFishingId); // colleague's fishing shows
+    expect(ids).not.toContain(ownerAFishingId); // own fishing filtered out
+    expect(ids).not.toContain(ownerBFishingId); // never another tenant
+  });
+
+  it('the member filter can never cross tenants', async () => {
+    const res = await request(apiService.server)
+      .get('/zvejyba/api/fishings')
+      .set(apiHelper.getHeaders(apiHelper.ownerA.token, apiHelper.tenantA.tenant.id))
+      .query({ query: JSON.stringify({ user: apiHelper.ownerB.user.id }) })
+      .expect(200);
+
+    // tenantB's user has no tenantA fishings → empty, and tenantB row never leaks.
+    expect(idsOf(res)).not.toContain(ownerBFishingId);
+  });
+
+  it('an object/operator user value is ignored (no injection, stays tenant-scoped)', async () => {
+    const res = await request(apiService.server)
+      .get('/zvejyba/api/fishings')
+      .set(apiHelper.getHeaders(apiHelper.ownerA.token, apiHelper.tenantA.tenant.id))
+      .query({ query: JSON.stringify({ user: { $ne: apiHelper.ownerA.user.id } }) })
+      .expect(200);
+
+    const ids = idsOf(res);
+    // Object rejected → no member narrowing → the whole tenantA journal,
+    // and crucially NO tenantB leak.
+    expect(ids).toContain(userAFishingId);
+    expect(ids).toContain(ownerAFishingId);
+    expect(ids).not.toContain(ownerBFishingId);
+  });
+
+  it('a personal-profile user still cannot filter by another user (unchanged)', async () => {
+    const res = await request(apiService.server)
+      .get('/zvejyba/api/fishings')
+      .set(apiHelper.getHeaders(apiHelper.freelancerA.token))
+      .query({ query: JSON.stringify({ user: apiHelper.userA.user.id }) })
+      .expect(200);
+
+    // Personal profile is forced to self → cannot see the tenant member's row.
+    expect(idsOf(res)).not.toContain(userAFishingId);
+  });
+
+  it('an admin can still filter fishings by any user', async () => {
+    const res = await request(apiService.server)
+      .get('/zvejyba/api/fishings')
+      .set(apiHelper.getHeaders(apiHelper.superAdmin.token))
+      .query({ query: JSON.stringify({ user: apiHelper.ownerB.user.id }) })
+      .expect(200);
+
+    const ids = idsOf(res);
+    expect(ids).toContain(ownerBFishingId);
+    expect(ids).not.toContain(userAFishingId);
+  });
+});


### PR DESCRIPTION
Backend support for the new žvejybos žurnalas filters (admin + citizen).

## 1. Member filter (by person, company profiles)

Filtering the journal **by person**: for an admin this already worked
(ProfileMixin doesn't scope admins). For a **company (tenant-profile) member**
it didn't — ProfileMixin strips `user` from caller queries as a FORBIDDEN key.

New fishings-local `beforeJournalSelect` (list/find/count/all) runs the shared
scoping, then re-applies a `user` narrowing **only for tenant profiles**,
**only as a single alphanumeric scalar** (`scalarMemberId` rejects
objects/operators/`$raw`/comma-lists), with `tenant: profile` still enforced.
Exposes nothing new (members already see the whole tenant journal), never
crosses tenants; admins/personal profiles unchanged.

## 2. Location options (`GET /fishings/locations`)

The location filter needs a dropdown, but no location-list endpoint exists
(`GET /location` is a point→location reverse lookup). New action returns the
**distinct locations the caller actually fished**, scoped like the journal
(admin → all, company → its tenant, freelancer → own) via the scoped
`fishings.find`. Names resolved like the `location` virtual field; external
UETK call wrapped so a down UETK degrades to "polders only". Each option
carries a `polder` flag so the client filters `polderId` vs `uetkCadastralId`.

## Tests

- `fishings-member-filter.spec.ts` (6): colleague narrowing; no cross-tenant;
  object & comma-list rejected; personal self-only; admin any user; count total.
- `fishings-location-options.spec.ts` (3): company sees only its fished
  locations; admin sees all; freelancer → [].
- Full suite: **28 suites / 181 tests** green. Security-reviewed (no P0/P1).

Frontend: biip-admin-web #497, biip-zvejyba-web #158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)