### PR TITLE
feat(fishings): žurnalo lokacijos filtras pagal konkrečią vietą (barą/telkinį/polderį)

### DIFF
--- a/services/fishings.service.ts
+++ b/services/fishings.service.ts
@@ -396,17 +396,7 @@ export default class FishTypesService extends moleculer.Service {
       ctx.params.uetkCadastralId = '00070001'; // Kuršių marios
     }
 
-    const fishing = await this.createEntity(ctx, { ...ctx.params, startEvent: startEvent.id });
-
-    // A new fishing may add a location → drop the cached `fishingLocations`
-    // options for the views that include it (admin's all-list + the creator's
-    // own scope). Other tenants' caches stay valid.
-    await this.broker.cacher?.del([
-      'fishings.locations:admin',
-      `fishings.locations:${this.fishingLocationsScope(ctx)}`,
-    ]);
-
-    return fishing;
+    return this.createEntity(ctx, { ...ctx.params, startEvent: startEvent.id });
   }
 
   @Action({
@@ -530,7 +520,7 @@ export default class FishTypesService extends moleculer.Service {
   // doesn't scope them); personal profiles keep `user` stripped (forced to
   // self) — see security-regression spec.
   @Method
-  beforeJournalSelect(ctx: Context<{ query?: { user?: unknown } }, UserAuthMeta>) {
+  async beforeJournalSelect(ctx: Context<{ query?: Record<string, unknown> }, UserAuthMeta>) {
     const requestedMember = this.scalarMemberId(ctx.params?.query?.user);
 
     this.beforeSelect(ctx);
@@ -543,7 +533,45 @@ export default class FishTypesService extends moleculer.Service {
     if (!isAdmin && isTenantProfile && requestedMember != null) {
       ctx.params.query = { ...ctx.params.query, user: requestedMember };
     }
+
+    await this.applyLocationFilter(ctx);
     return ctx;
+  }
+
+  // Event-based location filter. The granular location lives on the tool
+  // events, not the fishing row, so translate the picked `{ locationId,
+  // locationName }` into the fishings that have a build/remove event there and
+  // constrain the list by id. The outer ProfileMixin scope (tenant/user) still
+  // applies, so this can never cross tenants. Matched by id AND name because
+  // bar and polder ids can collide. The transport keys are always stripped so
+  // they never reach the list as bogus column filters.
+  @Method
+  async applyLocationFilter(ctx: Context<{ query?: Record<string, unknown> }, UserAuthMeta>) {
+    const query = ctx.params?.query;
+    if (!query) return;
+
+    const locationId = query.locationId;
+    const locationName = query.locationName;
+    delete query.locationId;
+    delete query.locationName;
+
+    if (
+      locationId == null ||
+      locationName == null ||
+      typeof locationId === 'object' ||
+      typeof locationName === 'object'
+    ) {
+      return;
+    }
+
+    const rows = await this.rawQuery(
+      ctx,
+      `SELECT DISTINCT fishing_id FROM tools_groups_events
+       WHERE location->>'id' = ? AND location->>'name' = ? AND deleted_at IS NULL`,
+      [String(locationId), String(locationName)],
+    );
+    const ids = rows.map((r: any) => Number(r.fishing_id)).filter(Number.isFinite);
+    query.id = { $in: ids.length ? ids : [-1] };
   }
 
   // Accept only a single bare scalar id. An object/array is the only way to
@@ -559,61 +587,42 @@ export default class FishTypesService extends moleculer.Service {
   }
 
   // Distinct locations that appear in the caller's fishings — options for the
-  // journal "location" filter. Scope is whatever `fishings.find` applies to
-  // the caller (admin → all, company → its tenant, freelancer → own), so the
-  // dropdown only lists places actually fished. Names are resolved the same
-  // way as the `location` virtual field; the external UETK lookup is wrapped
-  // defensively so a slow/down UETK degrades to "polders only" instead of
-  // breaking the whole filter. Each option carries `polder` so the client
-  // knows whether the selection filters `polderId` or `uetkCadastralId`.
+  // journal "location" filter. The granular location (estuary bar, inland water
+  // body, polder) lives in `tools_groups_events.location` JSONB, NOT on the
+  // fishing row: a fishing spans several bars, and every ESTUARY fishing carries
+  // the same fixed "Kuršių marios" cadastral id. So we read the distinct event
+  // locations, scoped exactly like the journal via the ProfileMixin-scoped
+  // `toolsGroupsEvents.find` (admin → all, company → its tenant, freelancer →
+  // own). Each option is { id, name }; the client filters by both, because bar
+  // and polder ids can collide (see toolsGroups "Tools-by-location collision").
   @Action({
     rest: 'GET /locations',
     auth: RestrictionType.DEFAULT,
   })
   async fishingLocations(ctx: Context<unknown, UserAuthMeta>) {
-    // Per-scope cache: the result differs by caller (admin → all, company →
-    // its tenant, freelancer → own), so the key MUST carry the scope or one
-    // tenant would read another's cached list. Built explicitly (not
-    // declarative `#meta` keys) so the scope is provably in the key. Saves the
-    // distinct query + the external UETK resolve on repeat opens and on the
-    // async-select's per-keystroke option fetches. Invalidated on startFishing.
+    // Per-scope cache: the result differs by caller, so the key MUST carry the
+    // scope or one tenant would read another's list. TTL only — locations
+    // change slowly, so a new bar showing up within the hour is acceptable.
     const cacheKey = `fishings.locations:${this.fishingLocationsScope(ctx)}`;
     const cached = await this.broker.cacher?.get(cacheKey);
     if (cached) return cached;
 
-    const fishings: Array<{ uetkCadastralId?: string; polderId?: number }> = await ctx.call(
-      'fishings.find',
-      { query: {}, fields: ['uetkCadastralId', 'polderId'] },
+    const events: Array<{ location?: { id?: string; name?: string } }> = await ctx.call(
+      'toolsGroupsEvents.find',
+      { query: {}, fields: ['location'] },
     );
 
-    const cadastralIds = Array.from(
-      new Set(fishings.map((f) => f.uetkCadastralId).filter((id): id is string => !!id)),
-    );
-    const polderIds = Array.from(
-      new Set(fishings.map((f) => f.polderId).filter((id): id is number => id != null)),
-    );
-
-    let waterBodies: Array<{ id: string; name: string }> = [];
-    if (cadastralIds.length) {
-      try {
-        waterBodies = await ctx.call('locations.uetkSearchByCadastralId', {
-          cadastralId: cadastralIds,
-        });
-      } catch (err: any) {
-        this.logger.warn(`[fishingLocations] UETK lookup failed: ${err?.message}`);
-      }
+    const byKey = new Map<string, { id: string; name: string }>();
+    for (const event of events) {
+      const loc = event.location;
+      if (!loc?.id || !loc?.name) continue;
+      const key = `${loc.id}|${loc.name}`;
+      if (!byKey.has(key)) byKey.set(key, { id: String(loc.id), name: loc.name });
     }
-    const polders: Polder[] = polderIds.length
-      ? await ctx.call('polders.find', { query: { id: { $in: polderIds } } })
-      : [];
 
-    const options = [
-      ...(waterBodies || [])
-        .filter((l) => !!l)
-        .map((l) => ({ id: l.id, name: l.name, polder: false })),
-      ...polders.map((p) => ({ id: p.id, name: p.name, polder: true })),
-    ];
-    options.sort((a, b) => (a.name || '').localeCompare(b.name || '', 'lt'));
+    const options = Array.from(byKey.values()).sort((a, b) =>
+      (a.name || '').localeCompare(b.name || '', 'lt'),
+    );
     await this.broker.cacher?.set(cacheKey, options, 60 * 60);
     return options;
   }

--- a/test/integration/api/fishings-location-options.spec.ts
+++ b/test/integration/api/fishings-location-options.spec.ts
@@ -1,72 +1,85 @@
 'use strict';
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { ServiceBroker } from 'moleculer';
+import request from 'supertest';
 import { ApiHelper, serviceBrokerConfig } from '../../helpers/api';
 
-// `fishings.fishingLocations` powers the journal "location" filter: the
-// distinct places the caller actually fished, scoped like the journal itself
-// (admin → all, company → its tenant, freelancer → own). Tested with POLDERS
-// fishings only — polders resolve from the local table, so no external UETK
-// call is needed (that branch is defensively wrapped anyway).
+// `fishings.fishingLocations` powers the journal "location" filter. The
+// granular location (estuary bar, inland water body, polder) lives in
+// `tools_groups_events.location` — NOT on the fishing row — so the options are
+// the distinct event locations, scoped like the journal, and the filter
+// (?query={locationId,locationName}) returns the fishings that have an event
+// there. Seeded with the real build flow so a real tools_groups_event exists.
 const broker = new ServiceBroker(serviceBrokerConfig);
 const apiHelper = new ApiHelper(broker);
-apiHelper.initializeServices();
+const apiService = apiHelper.initializeServices();
 
-let polderAId: number;
-let polderBId: number;
+const sampleCoords = { x: 21.13, y: 55.71 };
+const barFive = { id: '5', name: 'baras 5', type: 'ESTUARY', municipality: { id: 41, name: 'Klaipėda' } };
+const barSix = { id: '6', name: 'baras 6', type: 'ESTUARY', municipality: { id: 41, name: 'Klaipėda' } };
+
+let ownerAFishingId: any;
+let ownerBFishingId: any;
+
+// Start an ESTUARY fishing for `owner` and build a net at `location`, which
+// creates the tools_groups_event carrying that location. Returns the fishing id.
+async function buildAt(owner: any, tenantId: any, sealNr: string, location: any) {
+  const meta = apiHelper.meta(owner, tenantId);
+  const headers = apiHelper.getHeaders(owner.token, tenantId);
+  const toolTypes: any[] = await broker.call('toolTypes.find');
+  await broker.call(
+    'tools.create',
+    { sealNr, toolType: toolTypes[0].id, data: { eyeSize: 60, netLength: 30 } },
+    { meta },
+  );
+  await broker.call('fishings.startFishing', { type: 'ESTUARY', coordinates: sampleCoords }, { meta });
+  const fishing: any = await broker.call('fishings.currentFishing', {}, { meta });
+  const groups: any[] = await broker.call(
+    'toolsGroups.find',
+    { query: { removeEvent: { $exists: false } } },
+    { meta },
+  );
+  await request(apiService.server)
+    .post(`/zvejyba/api/toolsGroups/build/${groups[0].id}`)
+    .set(headers)
+    .send({ coordinates: sampleCoords, location })
+    .expect(200);
+  return fishing.id;
+}
 
 beforeAll(async () => {
   await broker.start();
   await apiHelper.setup();
-
-  const polders: any[] = await broker.call('polders.find');
-  polderAId = polders[0].id;
-  polderBId = polders[1].id;
-
-  const adminMeta = { authToken: apiHelper.superAdmin.token };
-  await broker.call(
-    'fishings.create',
-    { type: 'POLDERS', tenant: apiHelper.tenantA.tenant.id, user: apiHelper.ownerA.user.id, polderId: polderAId },
-    { meta: adminMeta },
-  );
-  await broker.call(
-    'fishings.create',
-    { type: 'POLDERS', tenant: apiHelper.tenantB.tenant.id, user: apiHelper.ownerB.user.id, polderId: polderBId },
-    { meta: adminMeta },
-  );
+  ownerAFishingId = await buildAt(apiHelper.ownerA, apiHelper.tenantA.tenant.id, 'S-LA-1', barFive);
+  ownerBFishingId = await buildAt(apiHelper.ownerB, apiHelper.tenantB.tenant.id, 'S-LB-1', barSix);
 });
 afterAll(() => broker.stop());
 
-const polderIds = (res: any[]) => res.filter((o) => o.polder).map((o) => o.id);
+const names = (res: any[]) => res.map((o) => o.name);
+const rowIds = (res: any) => (res.body.rows ?? []).map((r: any) => r.id);
 
-describe('fishings.fishingLocations — journal location options', () => {
+describe('fishings.fishingLocations — granular event-location options', () => {
   it('a company sees only the locations its own tenant fished', async () => {
     const res: any[] = await broker.call(
       'fishings.fishingLocations',
       {},
       { meta: apiHelper.meta(apiHelper.ownerA, apiHelper.tenantA.tenant.id) },
     );
-    const ids = polderIds(res);
-    expect(ids).toContain(polderAId);
-    expect(ids).not.toContain(polderBId); // never another tenant's location
-    // Options carry a name + a `polder` discriminator for the client.
-    const opt = res.find((o) => o.id === polderAId);
-    expect(opt).toMatchObject({ polder: true });
-    expect(typeof opt.name).toBe('string');
+    expect(names(res)).toContain('baras 5');
+    expect(names(res)).not.toContain('baras 6'); // never another tenant's bar
+    expect(res.find((o) => o.name === 'baras 5')).toMatchObject({ id: '5' });
   });
 
-  it('an admin sees locations across all tenants', async () => {
+  it('an admin sees event locations across all tenants', async () => {
     const res: any[] = await broker.call(
       'fishings.fishingLocations',
       {},
       { meta: apiHelper.meta(apiHelper.superAdmin) },
     );
-    const ids = polderIds(res);
-    expect(ids).toContain(polderAId);
-    expect(ids).toContain(polderBId);
+    expect(names(res)).toEqual(expect.arrayContaining(['baras 5', 'baras 6']));
   });
 
-  it('a freelancer with no fishings gets an empty list', async () => {
+  it('a freelancer with no tool events gets an empty list', async () => {
     const res: any[] = await broker.call(
       'fishings.fishingLocations',
       {},
@@ -74,29 +87,35 @@ describe('fishings.fishingLocations — journal location options', () => {
     );
     expect(res).toEqual([]);
   });
+});
 
-  it('starting a fishing invalidates the cached options for that scope', async () => {
-    const ownerMeta = apiHelper.meta(apiHelper.ownerA, apiHelper.tenantA.tenant.id);
-    const cacheKey = `fishings.locations:t:${apiHelper.tenantA.tenant.id}`;
+describe('fishings journal — location filter', () => {
+  it('returns the fishings that have an event at the picked location', async () => {
+    const res = await request(apiService.server)
+      .get('/zvejyba/api/fishings')
+      .set(apiHelper.getHeaders(apiHelper.ownerA.token, apiHelper.tenantA.tenant.id))
+      .query({ query: JSON.stringify({ locationId: '5', locationName: 'baras 5' }) })
+      .expect(200);
+    expect(rowIds(res)).toContain(ownerAFishingId);
+  });
 
-    // Prime the cache for this scope.
-    await broker.call('fishings.fishingLocations', {}, { meta: ownerMeta });
-    expect(await broker.cacher!.get(cacheKey)).toBeTruthy();
+  it('excludes fishings that were not at that location', async () => {
+    const res = await request(apiService.server)
+      .get('/zvejyba/api/fishings')
+      .set(apiHelper.getHeaders(apiHelper.ownerA.token, apiHelper.tenantA.tenant.id))
+      .query({ query: JSON.stringify({ locationId: '6', locationName: 'baras 6' }) })
+      .expect(200);
+    expect(rowIds(res)).not.toContain(ownerAFishingId);
+  });
 
-    // A new fishing must drop the entry (proves the `cacher.del([...])` call
-    // actually fires and removes the right keys — not just a no-op).
-    const toolTypes: any[] = await broker.call('toolTypes.find');
-    await broker.call(
-      'tools.create',
-      { sealNr: 'S-INV-1', toolType: toolTypes[0].id, data: { eyeSize: 60, netLength: 30 } },
-      { meta: ownerMeta },
-    );
-    await broker.call(
-      'fishings.startFishing',
-      { type: 'POLDERS', coordinates: { x: 21.13, y: 55.71 }, polderId: polderAId },
-      { meta: ownerMeta },
-    );
-
-    expect(await broker.cacher!.get(cacheKey)).toBeFalsy();
+  it('cannot reach another tenant via the location filter', async () => {
+    // ownerB filters by ownerA's bar → tenant scope keeps ownerA's fishing out.
+    const res = await request(apiService.server)
+      .get('/zvejyba/api/fishings')
+      .set(apiHelper.getHeaders(apiHelper.ownerB.token, apiHelper.tenantB.tenant.id))
+      .query({ query: JSON.stringify({ locationId: '5', locationName: 'baras 5' }) })
+      .expect(200);
+    expect(rowIds(res)).not.toContain(ownerAFishingId);
+    expect(rowIds(res)).not.toContain(ownerBFishingId); // ownerB wasn't at baras 5
   });
 });


### PR DESCRIPTION
Follow-up po #137: lokacijos filtras buvo **pagal žvejybos eilutės** `uetkCadastralId`/`polderId`, bet **kiekviena ESTUARY žvejyba turi fiksuotą „Kuršių marios"** cadastral id → visos estuarijos žvejybos suplokštėjo į vieną opciją. Tikroji vieta (baras 5, baras 6, upė, polderis) yra **`tools_groups_events.location`** JSONB.

## Pakeitimai

- **`fishingLocations`** dabar grąžina distinct `{id, name}` iš (ProfileMixin-scope'into) `tools_groups_events` — barai, telkiniai, polderiai vienodai. Cache → **TTL-only** (start-fishing invalidacija buvo seno, klaidingo šaltinio).
- **Žurnalo sąrašas** priima `query.{locationId,locationName}`; `beforeJournalSelect` (dabar async) per raw subquery suranda žvejybas, turinčias įvykį toje vietoje, ir apriboja sąrašą pagal `id` (išorinis tenant/user scope vis tiek galioja → negali peržengti įmonių). Sutapdina **id IR name** (barų/polderių id gali kirstis).

## Testai

`fishings-location-options.spec` perrašytas su tikru build flow:
- opcijos rodo barą; ne kitos įmonės barą; admin — visus; freelancer → []
- filtras grąžina tos vietos žvejybą; pašalina kitas; **negali pasiekti kitos įmonės per lokaciją**

Pilna suite: **28 suites / 184 testai** ✅

## FE
biip-admin-web + biip-zvejyba-web siunčia `query.locationId`+`query.locationName` (atskiri PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)