### PR TITLE
fix(security): close mass-delete, SQLi and cross-tenant IDOR holes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,38 @@ collide** (polder id 1 vs bar 1). `toolsGroupsByLocation` filters by
 by stored `location.type` (legacy rows have it null). Don't change this
 without re-thinking the legacy fallback.
 
+### Action exposure — `mappingPolicy: 'all'` publishes EVERY action
+
+The gateway (`api.service.ts`) runs `mappingPolicy: 'all'` + `whitelist:
+['**']`, so moleculer-web's fallback URL serves **any `published` action**
+at `POST /zvejyba/api/<service>/<action>` — `rest: null` does NOT hide it
+(only `visibility: 'protected'`/`'private'` does). Two consequences when
+adding code:
+
+1. **A destructive/internal action with no `auth` is reachable by any USER.**
+   `getRestrictionType` falls back to `RestrictionType.DEFAULT` (= USER or
+   ADMIN) when neither the action nor `settings.auth` sets one. Every
+   `DbConnection` service inherits `removeAllEntities` (an unscoped hard
+   `DELETE FROM`), so it MUST stay `visibility: 'protected'` (see
+   database.mixin.ts) — same reason `users.resolve` is protected. Internal
+   `broker.call`/`ctx.call` still reach protected actions.
+2. **Scope hooks only run on the verbs you wire them to.** `beforeSelect`
+   typically covers `list/find/count/get/all` — NOT `update`/`remove`/
+   `resolve`. So the generic `update`/`remove` are unscoped cross-tenant
+   writes/deletes unless you set them `auth: ADMIN` or add a `before`
+   guard (e.g. `tenantUsers.beforeRemove` checks OWNER/USER_ADMIN + same
+   tenant). Internal `ctx.call` bypasses the gateway, so locking the HTTP
+   auth never breaks service-to-service flows.
+
+### `$raw` query operator = SQL sink — deep-strip user queries
+
+`@moleculer/database`'s knex adapter executes `query.$raw` as `whereRaw`
+**and recurses into every nested object**, so `query[$or][0][id][$raw]`
+reaches raw SQL. Top-level-only stripping is bypassable — `sanitizeUserQuery`
+(profile.mixin) and `sanitizeQueryForTenantScope` (users.service) must
+`stripRawDeep` the user query at every depth. Server-built `$raw` clauses
+(parameterized, spread in AFTER sanitization) are unaffected.
+
 ### Virtual-field populate gotchas
 
 When a service uses `secure: true` on its primary key (every service in
@@ -228,6 +260,27 @@ appear without the `call` prefix (e.g. `mol $ tenants-import --dry`).
 
 ## Recent fix log (worth knowing)
 
+- **mass-delete/privesc/SQLi batch** — closed three systemic holes from a
+  security audit: (1) `removeAllEntities` → `visibility: 'protected'` so the
+  `mappingPolicy: 'all'` fallback URL can't wipe tables; (2) nested `$raw`
+  deep-stripped from user queries (profile.mixin + users.service) to kill
+  SQL injection via `query[$or][…][$raw]`; (3) `tenantUsers.update` → ADMIN
+  and a `beforeRemove` guard (OWNER/USER_ADMIN + same-tenant) so a USER can't
+  self-promote or touch another tenant's membership. Tests:
+  `security-mass-delete-privesc.spec.ts`. See "Action exposure" + "`$raw`
+  query operator" patterns above.
+- **cross-tenant IDOR batch** — the default db `update`/`remove` (and
+  toolsGroups' `:id` custom actions, which used the unscoped
+  `toolsGroups.resolve`) ran no tenant scope, so a USER could edit/delete
+  another tenant's rows by id. Added `ProfileMixin.beforeMutate` (mirrors
+  `tools.beforeDelete`) and wired it into the mutation verbs of fishings,
+  toolsGroups (+ build/connect/disconnect/remove/weigh), tools, weightEvents,
+  fishingEvents, toolsGroupsEvents, researches. Also locked `researches.fishes`
+  to ADMIN over HTTP (internal-only, no tenant/user column) and pinned
+  `researches.listRelated` to `publicFields` (was leaking investigator PII via
+  caller-chosen `fields`/`populate`). Tests: `security-cross-tenant-idor.spec.ts`.
+  Deferred: unauthenticated Prometheus `/metrics` on :3030 — infra-side (verify
+  biip-infra never proxies 3030; binding to localhost risks breaking scraping).
 - **PR #117** — `location_manual` boolean on `tools_groups_events` /
   `weight_events` plus virtual `Fishing.hasManualLocation`. First cut
   used `ctx.call('…events.find', { fields: ['fishing'] })` for the

--- a/mixins/database.mixin.ts
+++ b/mixins/database.mixin.ts
@@ -109,8 +109,18 @@ export default function (opts: any = {}) {
         return this.findEntity(ctx);
       },
 
-      async removeAllEntities(ctx: any) {
-        return await this.clearEntities(ctx);
+      // `clearEntities` is an unscoped hard `DELETE FROM <table>` (bypasses
+      // soft-delete and tenant scope). It must NEVER be HTTP-reachable: the
+      // gateway runs `mappingPolicy: 'all'`, so without `protected` any
+      // authenticated USER could `POST /<service>/removeAllEntities` and wipe
+      // every tenant's rows (security audit — mass deletion). `protected`
+      // keeps internal `broker.call`/`ctx.call` (tests, seeds) working while
+      // moleculer-web refuses to serve it (mirrors `users.resolve`).
+      removeAllEntities: {
+        visibility: 'protected',
+        handler(ctx: any) {
+          return this.clearEntities(ctx);
+        },
       },
 
       async populateByProp(
@@ -164,11 +174,7 @@ export default function (opts: any = {}) {
 
         return ids.filter((id) => queryIds.indexOf(id) >= 0);
       },
-      async rawQuery(
-        ctx: Context,
-        sql: string,
-        bindings?: readonly any[],
-      ): Promise<any[]> {
+      async rawQuery(ctx: Context, sql: string, bindings?: readonly any[]): Promise<any[]> {
         const adapter = await (this as any).getAdapter(ctx);
         const knex = adapter.client;
         const result = await knex.raw(sql, (bindings ?? []) as any[]);

--- a/mixins/profile.mixin.ts
+++ b/mixins/profile.mixin.ts
@@ -1,5 +1,7 @@
 import { Context } from 'moleculer';
 import { AuthUserRole, UserAuthMeta } from '../services/api.service';
+import { throwNoRightsError } from '../types';
+import { stripRawDeep } from '../utils';
 
 // Drop keys that would bypass the tenant/user scope or smuggle raw SQL
 // through moleculer-knex-filters. User-supplied query may still include
@@ -7,12 +9,15 @@ import { AuthUserRole, UserAuthMeta } from '../services/api.service';
 // that overlap with what this mixin enforces.
 const FORBIDDEN_USER_QUERY_KEYS = ['tenant', 'user', '$raw'] as const;
 
+// `$raw` (the knex adapter's `whereRaw` sink) must be stripped at EVERY depth —
+// `query[$or][0][id][$raw]` reaches raw SQL otherwise. Shared with
+// users.service via `stripRawDeep` so the two scope sanitizers can't diverge.
 function sanitizeUserQuery(query: any) {
   if (!query || typeof query !== 'object') return {};
   const clean: Record<string, any> = {};
   for (const key of Object.keys(query)) {
     if ((FORBIDDEN_USER_QUERY_KEYS as readonly string[]).includes(key)) continue;
-    clean[key] = query[key];
+    clean[key] = stripRawDeep(query[key]);
   }
   return clean;
 }
@@ -22,7 +27,9 @@ export default {
     beforeSelect(ctx: Context<any, UserAuthMeta>) {
       if (ctx.meta) {
         if (
-          ![AuthUserRole.SUPER_ADMIN, AuthUserRole.ADMIN].some((r) => r === ctx.meta?.authUser?.type)
+          ![AuthUserRole.SUPER_ADMIN, AuthUserRole.ADMIN].some(
+            (r) => r === ctx.meta?.authUser?.type,
+          )
         ) {
           // Security clauses MUST be spread last so user-supplied query
           // (`?query[tenant]=99`, `query.user=99`, or `query.$raw`) cannot
@@ -68,6 +75,38 @@ export default {
         const userId = ctx.meta.user?.id;
         ctx.params.tenant = profile || null;
         ctx.params.user = userId;
+      }
+      return ctx;
+    },
+    // Ownership guard for id-based mutations (`update`/`remove` and custom
+    // actions that mutate a row by `:id`). The read scope lives in
+    // `beforeSelect`, but the default db `update`/`remove` actions never run
+    // it, so without this a USER can edit/delete another tenant's row by id
+    // (cross-tenant IDOR). Mirrors the scope query in `beforeSelect` /
+    // `tools.beforeDelete`: tenant members are scoped to the tenant, a
+    // freelancer to their own personal (tenant-less) rows.
+    async beforeMutate(ctx: Context<{ id?: number | string }, UserAuthMeta>) {
+      // Internal/service calls (events, cron) carry no auth meta — leave them
+      // alone, exactly like `beforeCreate`.
+      if (!ctx.meta?.authUser) return ctx;
+      if (
+        [AuthUserRole.SUPER_ADMIN, AuthUserRole.ADMIN].some(
+          (role) => role === ctx.meta.authUser.type,
+        )
+      ) {
+        return ctx;
+      }
+      const id = ctx.params?.id;
+      if (id == null) return ctx;
+      const owned = await (this as any).findEntity(ctx, {
+        query: {
+          id,
+          tenant: ctx.meta.profile ? ctx.meta.profile : { $exists: false },
+          user: ctx.meta.profile ? { $exists: true } : ctx.meta.user?.id,
+        },
+      });
+      if (!owned) {
+        throwNoRightsError('Resource is not in your scope.');
       }
       return ctx;
     },

--- a/services/fishingEvents.service.ts
+++ b/services/fishingEvents.service.ts
@@ -126,6 +126,10 @@ export type FishingEvent<
   hooks: {
     before: {
       create: ['beforeCreate'],
+      // Cross-tenant IDOR guard for id-based mutations (the read scope in
+      // `beforeSelect` does not run on update/remove).
+      update: ['beforeMutate'],
+      remove: ['beforeMutate'],
       list: ['beforeSelect'],
       find: ['beforeSelect'],
       count: ['beforeSelect'],

--- a/services/fishings.service.ts
+++ b/services/fishings.service.ts
@@ -291,6 +291,10 @@ export type Fishing<
     before: {
       startFishing: ['beforeCreate'],
       skipFishing: ['beforeCreate'],
+      // `update` is ADMIN-only; `remove` (rest:null but reachable via the
+      // mappingPolicy fallback) had no scope — guard it so a USER can't
+      // delete another tenant's fishing by id.
+      remove: ['beforeMutate'],
       currentFishing: ['beforeSelect'],
       list: ['beforeSelect'],
       find: ['beforeSelect'],
@@ -482,9 +486,7 @@ export default class FishTypesService extends moleculer.Service {
   ) {
     if (!fishWeightEvents.length) return;
 
-    const hasAnyFishLogged = fishWeightEvents.some(
-      (w) => w.data && Object.keys(w.data).length > 0,
-    );
+    const hasAnyFishLogged = fishWeightEvents.some((w) => w.data && Object.keys(w.data).length > 0);
     if (!hasAnyFishLogged) {
       throw new moleculer.Errors.ValidationError(
         'Negalima baigti žvejybos: yra įrankių, pažymėtų kaip patikrinti, bet žuvies svoris dar neįrašytas. Pirmiausia įrašykite žuvis arba grąžinkite įrankius į sandėlį.',

--- a/services/researches.fishes.service.ts
+++ b/services/researches.fishes.service.ts
@@ -9,6 +9,7 @@ import {
   COMMON_SCOPES,
   CommonFields,
   CommonPopulates,
+  RestrictionType,
   Table,
 } from '../types';
 
@@ -37,6 +38,14 @@ export type ResearchFish<
     }),
   ],
   settings: {
+    // This entity is managed exclusively through the (INVESTIGATOR-gated)
+    // `researches` service via internal `ctx.call`; it has no `tenant`/`user`
+    // column to scope on and no FE consumer. `rest: false` does not hide it
+    // because the gateway's `mappingPolicy: 'all'` still serves
+    // `/researches.fishes/<action>` — without this any USER could read/write
+    // arbitrary research-fish rows by id. Lock all HTTP access to ADMIN;
+    // internal calls bypass the gateway and keep working.
+    auth: RestrictionType.ADMIN,
     fields: {
       id: {
         type: 'number',

--- a/services/researches.service.ts
+++ b/services/researches.service.ts
@@ -15,7 +15,6 @@ import {
   Table,
 } from '../types';
 
-import _ from 'lodash';
 import ProfileMixin from '../mixins/profile.mixin';
 import { GeomFeatureCollection } from '../modules/geometry';
 import { getFolderName } from '../utils';
@@ -225,6 +224,11 @@ export type Research<
   hooks: {
     before: {
       create: ['beforeCreate', 'handleMunicipality'],
+      // The generic remove (and the rest:null update reachable via the
+      // mappingPolicy fallback) had no scope — a USER could delete another
+      // tenant's research by id. Pin both to the caller.
+      update: ['beforeMutate'],
+      remove: ['beforeMutate'],
       list: ['beforeSelect'],
       find: ['beforeSelect'],
       count: ['beforeSelect'],
@@ -311,17 +315,19 @@ export default class ResearchesService extends moleculer.Service {
       };
     }
 
-    return ctx.call(
-      'researches.list',
-      _.merge({}, ctx.params || {}, {
-        query: {
-          cadastralId: research.cadastralId,
-          id: {
-            $ne: research.id,
-          },
-        },
-      }),
-    );
+    // Pin `fields` to the public allowlist and ignore any caller-supplied
+    // `fields`/`populate`/`scope` — otherwise a public caller can
+    // `?fields=user,tenant&populate=user` to dereference the investigator's
+    // PII. The sibling `listPublic`/`getPublic` already pin `publicFields`.
+    return ctx.call('researches.list', {
+      fields: publicFields,
+      page: ctx.params?.page || 1,
+      pageSize: ctx.params?.pageSize || 10,
+      query: {
+        cadastralId: research.cadastralId,
+        id: { $ne: research.id },
+      },
+    });
   }
 
   @Action({

--- a/services/tenantUsers.service.ts
+++ b/services/tenantUsers.service.ts
@@ -132,6 +132,11 @@ export type TenantUser<
       count: ['beforeSelect'],
       get: ['beforeSelect'],
       all: ['beforeSelect'],
+      // The generic `remove` stays USER-callable (the web app deletes a
+      // member via `DELETE /tenantUsers/:id`), so it MUST be guarded — see
+      // `beforeRemove`. Internal cascades (`users.removed`/`tenants.removed`)
+      // use `removeEntities` directly and skip this action hook.
+      remove: ['beforeRemove'],
     },
   },
 
@@ -145,8 +150,16 @@ export type TenantUser<
     create: {
       auth: RestrictionType.ADMIN,
     },
+    // The generic db `update` has NO ownership/tenant scope and accepts any
+    // `role`, so it must not be reachable by a USER — that is a self-promotion
+    // / cross-tenant privilege escalation (a USER could `POST
+    // /tenantUsers/update {id, role:"OWNER"}` via the mappingPolicy:'all'
+    // fallback). Members are edited through the guarded `updateTenantUser`
+    // (`PATCH /update/:id`), which OWNER/USER_ADMIN use; internal callers
+    // (`updateTenantUser`, `afterUserLoggedIn`) reach this via local ctx.call,
+    // which bypasses the gateway auth.
     update: {
-      auth: RestrictionType.DEFAULT,
+      auth: RestrictionType.ADMIN,
     },
     remove: {
       auth: RestrictionType.DEFAULT,
@@ -203,6 +216,13 @@ export default class TenantUsersService extends moleculer.Service {
       throwIfNotExist: true,
       populate: ['user'],
     });
+
+    // `tenantUsers.resolve` is not tenant-scoped, so a USER_ADMIN/OWNER of one
+    // tenant could otherwise pass another tenant's membership id and edit it
+    // (IDOR). Pin the target to the caller's active tenant.
+    if (String(tenantUser.tenant) !== String(profile)) {
+      throwNoRightsError('Cannot edit a user from another tenant.');
+    }
 
     const currentUser = tenantUser.user;
     const currentTenant: Tenant = await ctx.call('tenants.resolve', {
@@ -277,8 +297,7 @@ export default class TenantUsersService extends moleculer.Service {
     // `tenants.invite` creating the seed OWNER alongside a brand-new
     // tenant) don't have `x-profile`, so the body fallback stays open
     // only for them.
-    const isUserCaller =
-      !!ctx.meta?.user && ctx.meta?.authUser?.type === AuthUserRole.USER;
+    const isUserCaller = !!ctx.meta?.user && ctx.meta?.authUser?.type === AuthUserRole.USER;
 
     let tenantId: number | undefined | null;
     if (isUserCaller) {
@@ -396,6 +415,36 @@ export default class TenantUsersService extends moleculer.Service {
       id: userEntity.authUser,
       groupId: tenantEntity.authGroup,
     });
+  }
+
+  @Method
+  async beforeRemove(ctx: Context<{ id: number }, UserAuthMeta>) {
+    // Internal callers (the `users.removed`/`tenants.removed` cascades use
+    // `removeEntities`, not this action; seeds/ticks carry no auth) pass
+    // through untouched.
+    if (!ctx.meta?.authUser) return ctx;
+
+    // Platform admins manage any membership.
+    if (
+      [AuthUserRole.ADMIN, AuthUserRole.SUPER_ADMIN].some((role) => role === ctx.meta.authUser.type)
+    ) {
+      return ctx;
+    }
+
+    // A USER may remove members only if they are OWNER/USER_ADMIN of their
+    // active tenant, and only members that belong to that same tenant — the
+    // generic `remove` is otherwise an unscoped cross-tenant delete (IDOR).
+    validateCanEditTenantUser(ctx, 'Only OWNER and USER_ADMIN can remove users from tenant.');
+
+    const target: TenantUser = await ctx.call('tenantUsers.resolve', {
+      id: ctx.params.id,
+      throwIfNotExist: true,
+    });
+    if (String(target.tenant) !== String(ctx.meta.profile)) {
+      throwNoRightsError('Cannot remove a user from another tenant.');
+    }
+
+    return ctx;
   }
 
   @Method

--- a/services/tools.service.ts
+++ b/services/tools.service.ts
@@ -224,6 +224,10 @@ async function validateData({ ctx, params, entity, value }: FieldHookCallback) {
     before: {
       create: ['beforeCreate'],
       remove: ['beforeDelete'],
+      // `remove` has its own ownership check (`beforeDelete`); the generic
+      // `update` had none, so a USER could overwrite another tenant's sealed
+      // tool by id. `beforeMutate` scopes it to the caller.
+      update: ['beforeMutate'],
       availableTools: ['beforeSelect'],
       list: ['beforeSelect'],
       find: ['beforeSelect'],

--- a/services/toolsGroups.service.ts
+++ b/services/toolsGroups.service.ts
@@ -154,7 +154,18 @@ export type ToolsGroup<
   },
   hooks: {
     before: {
-      buildTools: ['beforeCreate'],
+      // Every `:id` mutation resolves a toolsGroup by id; `beforeMutate`
+      // pins that id to the caller's tenant/user so a USER can't build,
+      // connect, weigh, or remove tools on another tenant's group (the
+      // actions used `toolsGroups.resolve`, which is unscoped). The generic
+      // `update`/`remove` get the same guard.
+      buildTools: ['beforeMutate', 'beforeCreate'],
+      connectTools: ['beforeMutate'],
+      disconnectTools: ['beforeMutate'],
+      removeTools: ['beforeMutate'],
+      weighFish: ['beforeMutate'],
+      update: ['beforeMutate'],
+      remove: ['beforeMutate'],
       list: ['beforeSelect'],
       find: ['beforeSelect'],
       count: ['beforeSelect'],
@@ -664,13 +675,10 @@ export default class ToolsGroupsService extends moleculer.Service {
     // Same shape as `getNotCheckedToolsGroups` — `find` returns user-scoped
     // groups, IDs come back encoded so comparisons match `currentFishing.id`
     // without us having to think about `secure: true` decoding.
-    const activeGroups: ToolsGroup<'tools' | 'buildEvent'>[] = await ctx.call(
-      'toolsGroups.find',
-      {
-        query: { removeEvent: { $exists: false } },
-        populate: ['tools', 'buildEvent'],
-      },
-    );
+    const activeGroups: ToolsGroup<'tools' | 'buildEvent'>[] = await ctx.call('toolsGroups.find', {
+      query: { removeEvent: { $exists: false } },
+      populate: ['tools', 'buildEvent'],
+    });
 
     // Scope siblings by fishing + bar/location + tool type. Each bar is a
     // self-contained checking session — a net weighed with fish in bar 2
@@ -691,14 +699,10 @@ export default class ToolsGroupsService extends moleculer.Service {
       query: { fishing: currentFishing.id, toolsGroup: { $in: siblingIds } },
     });
 
-    const checkedGroupIds = new Set(
-      sibWeights.map((w) => w.toolsGroup).filter((id) => id != null),
-    );
+    const checkedGroupIds = new Set(sibWeights.map((w) => w.toolsGroup).filter((id) => id != null));
     if (checkedGroupIds.has(group.id)) return; // self already weighed/checked — allow
 
-    const anyWithFish = sibWeights.some(
-      (w) => w.data && Object.keys(w.data).length > 0,
-    );
+    const anyWithFish = sibWeights.some((w) => w.data && Object.keys(w.data).length > 0);
     const unchecked = siblings.length - checkedGroupIds.size;
 
     // We're the last unchecked of this type AND siblings only have empty

--- a/services/toolsGroupsEvents.service.ts
+++ b/services/toolsGroupsEvents.service.ts
@@ -171,6 +171,10 @@ export type ToolsGroupsEvent<
   hooks: {
     before: {
       create: ['beforeCreate'],
+      // Cross-tenant IDOR guard for id-based mutations (the read scope in
+      // `beforeSelect` does not run on update/remove).
+      update: ['beforeMutate'],
+      remove: ['beforeMutate'],
       list: ['beforeSelect'],
       find: ['beforeSelect'],
       count: ['beforeSelect'],

--- a/services/users.service.ts
+++ b/services/users.service.ts
@@ -14,7 +14,7 @@ import { TenantUser, TenantUserRole } from './tenantUsers.service';
 
 import ApiGateway from 'moleculer-web';
 import DbConnection, { PopulateHandlerFn } from '../mixins/database.mixin';
-import { isInGroup } from '../utils';
+import { isInGroup, stripRawDeep } from '../utils';
 import { AuthUserRole, UserAuthMeta } from './api.service';
 
 // Strip security-sensitive keys from user-supplied query before merging
@@ -22,12 +22,16 @@ import { AuthUserRole, UserAuthMeta } from './api.service';
 // profile.mixin.ts — caller-controlled `$raw` is especially dangerous
 // because moleculer-knex-filters executes it as raw SQL.
 const TENANT_SCOPE_FORBIDDEN_KEYS = ['$raw', 'tenants'] as const;
+
+// `$raw` is deep-stripped (see `stripRawDeep`) — a top-level-only strip is
+// bypassed by nesting it under any operator. The server-built `$raw` tenant
+// clause is spread in AFTER this runs, so it is unaffected.
 function sanitizeQueryForTenantScope(query: any) {
   if (!query || typeof query !== 'object') return {};
   const clean: Record<string, any> = {};
   for (const key of Object.keys(query)) {
     if ((TENANT_SCOPE_FORBIDDEN_KEYS as readonly string[]).includes(key)) continue;
-    clean[key] = query[key];
+    clean[key] = stripRawDeep(query[key]);
   }
   return clean;
 }
@@ -275,7 +279,6 @@ export default class UsersService extends moleculer.Service {
   async all(ctx: Context) {
     return this.findEntities(ctx);
   }
-
 
   @Action({
     rest: 'POST /:id/impersonate',

--- a/services/weightEvents.service.ts
+++ b/services/weightEvents.service.ts
@@ -160,6 +160,10 @@ export type WeightEvent<
   hooks: {
     before: {
       createWeightEvent: ['beforeCreate', 'beforeFishWeigh'],
+      // Scope id-based mutations to the caller — the generic update/remove
+      // are otherwise an unscoped cross-tenant edit/delete of catch records.
+      update: ['beforeMutate'],
+      remove: ['beforeMutate'],
       list: ['beforeSelect'],
       find: ['beforeSelect'],
       count: ['beforeSelect'],

--- a/test/integration/api/security-cross-tenant-idor.spec.ts
+++ b/test/integration/api/security-cross-tenant-idor.spec.ts
@@ -1,0 +1,149 @@
+'use strict';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { ServiceBroker } from 'moleculer';
+import request from 'supertest';
+import { ApiHelper, FixtureTenant, FixtureUser, serviceBrokerConfig } from '../../helpers/api';
+
+// P1 batch: the generic db `update`/`remove` (and toolsGroups' `:id` custom
+// mutations) ran no tenant scope, so a USER could edit/delete another tenant's
+// rows by id. `ProfileMixin.beforeMutate` now pins every id-based mutation to
+// the caller's tenant/user. Also: `researches.fishes` is locked to ADMIN over
+// HTTP, and `researches.listRelated` no longer leaks PII via caller-chosen
+// `fields`/`populate`.
+
+const broker = new ServiceBroker(serviceBrokerConfig);
+const apiHelper = new ApiHelper(broker);
+const apiService = apiHelper.initializeServices();
+
+let seq = 0;
+
+// Mirrors the valid shape in researches.spec.ts (numeric indices are required).
+const baseResearch = {
+  waterBodyData: { name: 'Lake', area: 10 },
+  predatoryFishesRelativeAbundance: 0.5,
+  predatoryFishesRelativeBiomass: 0.5,
+  averageWeight: 0.3,
+  valuableFishesRelativeBiomass: 0.4,
+  conditionIndex: 0.6,
+};
+
+async function newTool(owner: FixtureUser, tenant: FixtureTenant): Promise<any> {
+  const types: any[] = await broker.call('toolTypes.find');
+  const sealNr = `S-idor-${seq++}`;
+  const meta = apiHelper.meta(owner, tenant.tenant.id);
+  await broker.call(
+    'tools.create',
+    { sealNr, toolType: types[0].id, data: { eyeSize: 60, netLength: 30 } },
+    { meta },
+  );
+  return broker.call('tools.findOne', { query: { sealNr } }, { meta });
+}
+
+beforeAll(async () => {
+  await broker.start();
+  await apiHelper.setup();
+});
+afterAll(() => broker.stop());
+
+describe('cross-tenant write guard — generic tools.update (beforeMutate)', () => {
+  it('OWNER of tenantA CANNOT PATCH another tenant`s tool', async () => {
+    const toolB = await newTool(apiHelper.ownerB, apiHelper.tenantB);
+
+    const res = await request(apiService.server)
+      .patch(`/zvejyba/api/tools/${toolB.id}`)
+      .set(apiHelper.getHeaders(apiHelper.ownerA.token, apiHelper.tenantA.tenant.id))
+      .send({ data: { eyeSize: 999, netLength: 30 } });
+    expect([401, 403]).toContain(res.status);
+
+    // The foreign tool is untouched.
+    const after: any = await broker.call(
+      'tools.findOne',
+      { query: { id: toolB.id } },
+      { meta: apiHelper.meta(apiHelper.superAdmin) },
+    );
+    expect(after.data.eyeSize).toBe(60);
+  });
+
+  it('OWNER CAN PATCH a tool in their OWN tenant', async () => {
+    const toolA = await newTool(apiHelper.ownerA, apiHelper.tenantA);
+
+    const res = await request(apiService.server)
+      .patch(`/zvejyba/api/tools/${toolA.id}`)
+      .set(apiHelper.getHeaders(apiHelper.ownerA.token, apiHelper.tenantA.tenant.id))
+      .send({ data: { eyeSize: 70, netLength: 30 } });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('cross-tenant delete guard — fishings.remove (beforeMutate)', () => {
+  it('USER cannot remove another tenant`s fishing by id', async () => {
+    const fishingB: any = await broker.call(
+      'fishings.create',
+      {
+        type: 'INLAND_WATERS',
+        tenant: apiHelper.tenantB.tenant.id,
+        user: apiHelper.ownerB.user.id,
+      },
+      { meta: { authToken: apiHelper.superAdmin.token } },
+    );
+
+    const res = await request(apiService.server)
+      .post('/zvejyba/api/fishings/remove')
+      .set(apiHelper.getHeaders(apiHelper.ownerA.token, apiHelper.tenantA.tenant.id))
+      .send({ id: fishingB.id });
+    expect([401, 403]).toContain(res.status);
+
+    // Still there.
+    const after: any = await broker.call(
+      'fishings.get',
+      { id: fishingB.id },
+      { meta: apiHelper.meta(apiHelper.superAdmin) },
+    );
+    expect(after.id).toBe(fishingB.id);
+  });
+});
+
+describe('researches.fishes is not USER-reachable over HTTP', () => {
+  it('USER cannot reach researches.fishes.find via the fallback URL', async () => {
+    const res = await request(apiService.server)
+      .post('/zvejyba/api/researches.fishes/find')
+      .set(apiHelper.getHeaders(apiHelper.ownerA.token, apiHelper.tenantA.tenant.id))
+      .send({});
+    expect([401, 403, 404]).toContain(res.status);
+  });
+
+  it('internal broker.call still works (research management path)', async () => {
+    const rows: any = await broker.call(
+      'researches.fishes.find',
+      {},
+      { meta: apiHelper.meta(apiHelper.superAdmin) },
+    );
+    expect(Array.isArray(rows)).toBe(true);
+  });
+});
+
+describe('researches.listRelated does not leak PII via caller-chosen fields', () => {
+  it('ignores ?fields=user,tenant&populate=user — only public fields returned', async () => {
+    const a: any = await broker.call(
+      'researches.create',
+      { ...baseResearch, cadastralId: '00079001', startAt: '2024-01-01', endAt: '2024-01-10' },
+      { meta: apiHelper.meta(apiHelper.superAdmin) },
+    );
+    await broker.call(
+      'researches.create',
+      { ...baseResearch, cadastralId: '00079001', startAt: '2025-01-01', endAt: '2025-01-10' },
+      { meta: apiHelper.meta(apiHelper.superAdmin) },
+    );
+
+    const res = await request(apiService.server)
+      .get(`/zvejyba/api/public/researches/${a.id}/related`)
+      .query({ fields: 'id,user,tenant', populate: 'user' })
+      .expect(200);
+
+    expect(res.body.total).toBeGreaterThanOrEqual(1);
+    for (const row of res.body.rows) {
+      expect(row).not.toHaveProperty('user');
+      expect(row).not.toHaveProperty('tenant');
+    }
+  });
+});

--- a/test/integration/api/security-mass-delete-privesc.spec.ts
+++ b/test/integration/api/security-mass-delete-privesc.spec.ts
@@ -1,0 +1,178 @@
+'use strict';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { ServiceBroker } from 'moleculer';
+import request from 'supertest';
+import { ApiHelper, serviceBrokerConfig } from '../../helpers/api';
+
+// Regression coverage for the security audit batch that closed three
+// systemic holes, all rooted in `mappingPolicy: 'all'` + per-verb scoping:
+//   1) `removeAllEntities` (unscoped hard DELETE) reachable by any USER →
+//      mass table wipe across every tenant.
+//   2) nested `$raw` in the user `query` reaching the knex `whereRaw` sink →
+//      arbitrary SQL injection on every list endpoint.
+//   3) the generic `tenantUsers.update` / `remove` (no ownership scope,
+//      free-form `role`) → USER self-promotion + cross-tenant membership
+//      tampering.
+
+const broker = new ServiceBroker(serviceBrokerConfig);
+const apiHelper = new ApiHelper(broker);
+const apiService = apiHelper.initializeServices();
+
+beforeAll(async () => {
+  await broker.start();
+  await apiHelper.setup();
+});
+afterAll(() => broker.stop());
+
+async function tenantUserId(userId: number | string, tenantId: number | string): Promise<number> {
+  const rows: any[] = await broker.call(
+    'tenantUsers.find',
+    { query: { user: userId, tenant: tenantId } },
+    { meta: apiHelper.meta(apiHelper.superAdmin) },
+  );
+  return rows[0].id;
+}
+
+describe('mass deletion — removeAllEntities is not HTTP-reachable', () => {
+  it('USER cannot POST /<service>/removeAllEntities (wipe is refused)', async () => {
+    const seeded: any = await broker.call(
+      'fishings.create',
+      {
+        type: 'INLAND_WATERS',
+        tenant: apiHelper.tenantA.tenant.id,
+        user: apiHelper.ownerA.user.id,
+      },
+      { meta: { authToken: apiHelper.superAdmin.token } },
+    );
+
+    const res = await request(apiService.server)
+      .post('/zvejyba/api/fishings/removeAllEntities')
+      .set(apiHelper.getHeaders(apiHelper.ownerA.token, apiHelper.tenantA.tenant.id));
+    // `protected` → moleculer-web refuses to serve it.
+    expect(res.status).toBe(404);
+
+    // The seeded row is untouched.
+    const after: any = await broker.call(
+      'fishings.get',
+      { id: seeded.id },
+      { meta: apiHelper.meta(apiHelper.superAdmin) },
+    );
+    expect(after.id).toBe(seeded.id);
+  });
+
+  it('internal broker.call still wipes (seed/test path keeps working)', async () => {
+    await broker.call('fishings.removeAllEntities');
+    const count: number = await broker.call(
+      'fishings.count',
+      {},
+      { meta: apiHelper.meta(apiHelper.superAdmin) },
+    );
+    expect(count).toBe(0);
+  });
+});
+
+describe('SQL injection — nested $raw is stripped from the user query', () => {
+  it('USER find with a NESTED $raw runs clean (operator removed, no SQL error)', async () => {
+    // If the nested `$raw` survived, it would reach `whereRaw('…not sql…')`
+    // and Postgres would reject the statement → the call rejects. A resolved
+    // array proves the operator was stripped before the adapter saw it.
+    const res: any = await broker.call(
+      'fishings.find',
+      { query: { id: { $gte: 0, $raw: 'this_is_not_valid_sql' } } },
+      { meta: apiHelper.meta(apiHelper.ownerA, apiHelper.tenantA.tenant.id) },
+    );
+    expect(Array.isArray(res)).toBe(true);
+  });
+
+  it('USER find with a $raw nested under $or is also stripped', async () => {
+    const res: any = await broker.call(
+      'fishings.find',
+      { query: { $or: [{ id: { $gte: 0, $raw: 'definitely; not; sql' } }] } },
+      { meta: apiHelper.meta(apiHelper.ownerA, apiHelper.tenantA.tenant.id) },
+    );
+    expect(Array.isArray(res)).toBe(true);
+  });
+
+  it('top-level $raw remains stripped (prior fix regression)', async () => {
+    const res: any = await broker.call(
+      'fishings.find',
+      { query: { $raw: 'still_not_sql' } },
+      { meta: apiHelper.meta(apiHelper.ownerA, apiHelper.tenantA.tenant.id) },
+    );
+    expect(Array.isArray(res)).toBe(true);
+  });
+});
+
+describe('privilege escalation — generic tenantUsers.update is ADMIN-only', () => {
+  it('USER cannot PATCH /tenantUsers/:id to self-promote to OWNER', async () => {
+    const tuId = await tenantUserId(apiHelper.userA.user.id, apiHelper.tenantA.tenant.id);
+
+    const res = await request(apiService.server)
+      .patch(`/zvejyba/api/tenantUsers/${tuId}`)
+      .set(apiHelper.getHeaders(apiHelper.userA.token, apiHelper.tenantA.tenant.id))
+      .send({ role: 'OWNER' });
+    expect([401, 403]).toContain(res.status);
+
+    const after: any = await broker.call(
+      'tenantUsers.resolve',
+      { id: tuId },
+      { meta: apiHelper.meta(apiHelper.superAdmin) },
+    );
+    expect(after.role).toBe('USER');
+  });
+
+  it('USER cannot reach the generic update via the /tenantUsers/update fallback URL', async () => {
+    const tuId = await tenantUserId(apiHelper.userA.user.id, apiHelper.tenantA.tenant.id);
+
+    const res = await request(apiService.server)
+      .post('/zvejyba/api/tenantUsers/update')
+      .set(apiHelper.getHeaders(apiHelper.userA.token, apiHelper.tenantA.tenant.id))
+      .send({ id: tuId, role: 'OWNER' });
+    expect([401, 403, 404]).toContain(res.status);
+
+    const after: any = await broker.call(
+      'tenantUsers.resolve',
+      { id: tuId },
+      { meta: apiHelper.meta(apiHelper.superAdmin) },
+    );
+    expect(after.role).toBe('USER');
+  });
+});
+
+describe('tenantUsers delete is guarded (beforeRemove) — OWNER keeps control', () => {
+  it('OWNER CAN delete a member of their OWN tenant', async () => {
+    const member = await apiHelper.makeTenantMember(apiHelper.tenantA, 'USER' as any);
+    const tuId = await tenantUserId(member.user.id, apiHelper.tenantA.tenant.id);
+
+    const res = await request(apiService.server)
+      .delete(`/zvejyba/api/tenantUsers/${tuId}`)
+      .set(apiHelper.getHeaders(apiHelper.ownerA.token, apiHelper.tenantA.tenant.id));
+    expect(res.status).toBe(200);
+  });
+
+  it('OWNER of tenantA CANNOT delete a member of tenantB (cross-tenant IDOR)', async () => {
+    const tuB = await tenantUserId(apiHelper.ownerB.user.id, apiHelper.tenantB.tenant.id);
+
+    const res = await request(apiService.server)
+      .delete(`/zvejyba/api/tenantUsers/${tuB}`)
+      .set(apiHelper.getHeaders(apiHelper.ownerA.token, apiHelper.tenantA.tenant.id));
+    expect([401, 403]).toContain(res.status);
+
+    const still: any = await broker.call(
+      'tenantUsers.resolve',
+      { id: tuB, throwIfNotExist: false },
+      { meta: apiHelper.meta(apiHelper.superAdmin) },
+    );
+    expect(still?.id).toBe(tuB);
+  });
+
+  it('plain USER (role USER) cannot delete a member', async () => {
+    const member = await apiHelper.makeTenantMember(apiHelper.tenantA, 'USER' as any);
+    const tuId = await tenantUserId(member.user.id, apiHelper.tenantA.tenant.id);
+
+    const res = await request(apiService.server)
+      .delete(`/zvejyba/api/tenantUsers/${tuId}`)
+      .set(apiHelper.getHeaders(apiHelper.userA.token, apiHelper.tenantA.tenant.id));
+    expect([401, 403]).toContain(res.status);
+  });
+});

--- a/test/integration/api/security-mass-delete-privesc.spec.ts
+++ b/test/integration/api/security-mass-delete-privesc.spec.ts
@@ -176,3 +176,79 @@ describe('tenantUsers delete is guarded (beforeRemove) — OWNER keeps control',
     expect([401, 403]).toContain(res.status);
   });
 });
+
+// The guards above MUST NOT over-block the legitimate flow: a tenant OWNER
+// (and USER_ADMIN, via the same `validateCanEditTenantUser` gate) keeps full
+// control of their OWN tenant's members — add, edit, delete. Each test asserts
+// the change actually took effect, not just a 200.
+describe('tenant OWNER keeps full member management (add / edit / delete)', () => {
+  it('OWNER can ADD a member via POST /tenantUsers/invite', async () => {
+    const res = await request(apiService.server)
+      .post('/zvejyba/api/tenantUsers/invite')
+      .set(apiHelper.getHeaders(apiHelper.ownerA.token, apiHelper.tenantA.tenant.id))
+      .send({
+        firstName: 'Added',
+        lastName: 'Member',
+        personalCode: '39010101010',
+        role: 'USER',
+        email: 'added.member@test.lt',
+      })
+      .expect(200);
+
+    expect(res.body.role).toBe('USER');
+    expect(String(res.body.tenant)).toBe(String(apiHelper.tenantA.tenant.id));
+
+    // The membership row really exists in the OWNER's tenant.
+    const created: any = await broker.call(
+      'tenantUsers.resolve',
+      { id: res.body.id },
+      { meta: apiHelper.meta(apiHelper.superAdmin) },
+    );
+    expect(String(created.tenant)).toBe(String(apiHelper.tenantA.tenant.id));
+  });
+
+  it('OWNER can EDIT a member`s role + contact via PATCH /tenantUsers/update/:id', async () => {
+    const member = await apiHelper.makeTenantMember(apiHelper.tenantA, 'USER' as any);
+    const tuId = await tenantUserId(member.user.id, apiHelper.tenantA.tenant.id);
+
+    await request(apiService.server)
+      .patch(`/zvejyba/api/tenantUsers/update/${tuId}`)
+      .set(apiHelper.getHeaders(apiHelper.ownerA.token, apiHelper.tenantA.tenant.id))
+      .send({ role: 'USER_ADMIN', email: 'edited.member@test.lt', phone: '+37061122334' })
+      .expect(200);
+
+    // Role change persisted on the membership…
+    const tu: any = await broker.call(
+      'tenantUsers.resolve',
+      { id: tuId },
+      { meta: apiHelper.meta(apiHelper.superAdmin) },
+    );
+    expect(tu.role).toBe('USER_ADMIN');
+
+    // …and contact details persisted on the member's user.
+    const u: any = await broker.call(
+      'users.resolve',
+      { id: member.user.id },
+      { meta: apiHelper.meta(apiHelper.superAdmin) },
+    );
+    expect(u.email).toBe('edited.member@test.lt');
+    expect(u.phone).toBe('+37061122334');
+  });
+
+  it('OWNER can DELETE a member via DELETE /tenantUsers/:id (row removed)', async () => {
+    const member = await apiHelper.makeTenantMember(apiHelper.tenantA, 'USER' as any);
+    const tuId = await tenantUserId(member.user.id, apiHelper.tenantA.tenant.id);
+
+    await request(apiService.server)
+      .delete(`/zvejyba/api/tenantUsers/${tuId}`)
+      .set(apiHelper.getHeaders(apiHelper.ownerA.token, apiHelper.tenantA.tenant.id))
+      .expect(200);
+
+    const gone: any = await broker.call(
+      'tenantUsers.resolve',
+      { id: tuId, throwIfNotExist: false },
+      { meta: apiHelper.meta(apiHelper.superAdmin) },
+    );
+    expect(gone).toBeFalsy();
+  });
+});

--- a/test/unit/strip-raw-deep.spec.ts
+++ b/test/unit/strip-raw-deep.spec.ts
@@ -1,0 +1,57 @@
+'use strict';
+import { describe, expect, it } from '@jest/globals';
+import { stripRawDeep } from '../../utils';
+
+// `stripRawDeep` is the single source of truth behind both scope sanitizers
+// (profile.mixin `sanitizeUserQuery`, users.service `sanitizeQueryForTenantScope`).
+// It must remove every `$raw` key at any depth — `$raw` reaches the knex
+// adapter's `whereRaw` raw-SQL sink — while leaving all other operators and
+// values intact.
+
+describe('stripRawDeep', () => {
+  it('removes a top-level $raw (string form)', () => {
+    expect(stripRawDeep({ $raw: '1=1' })).toEqual({});
+  });
+
+  it('removes a top-level $raw (object/condition form)', () => {
+    expect(stripRawDeep({ $raw: { condition: 'DROP TABLE x', bindings: [] } })).toEqual({});
+  });
+
+  it('removes $raw nested under a field operator', () => {
+    expect(stripRawDeep({ id: { $gte: 0, $raw: 'evil' } })).toEqual({ id: { $gte: 0 } });
+  });
+
+  it('removes $raw nested inside an $or array', () => {
+    const out = stripRawDeep({ $or: [{ id: { $raw: 'a' } }, { name: 'x' }] });
+    expect(out).toEqual({ $or: [{ id: {} }, { name: 'x' }] });
+  });
+
+  it('removes $raw at multiple depths simultaneously', () => {
+    const out = stripRawDeep({
+      $raw: 'top',
+      $and: [{ a: { $raw: 'deep' } }, { b: { c: { $raw: 'deeper' } } }],
+    });
+    expect(out).toEqual({ $and: [{ a: {} }, { b: { c: {} } }] });
+  });
+
+  it('preserves legitimate operators and scalar values', () => {
+    const query = {
+      type: 'INLAND_WATERS',
+      id: { $in: [1, 2, 3] },
+      $or: [{ tenant: 5 }, { deletedAt: { $exists: false } }],
+    };
+    expect(stripRawDeep(query)).toEqual(query);
+  });
+
+  it('passes scalars, null and undefined through untouched', () => {
+    expect(stripRawDeep('hello')).toBe('hello');
+    expect(stripRawDeep(42)).toBe(42);
+    expect(stripRawDeep(null)).toBeNull();
+    expect(stripRawDeep(undefined)).toBeUndefined();
+  });
+
+  it('only strips the literal key "$raw", not lookalikes', () => {
+    const query = { $rawish: 'kept', raw: 'kept', nested: { $raw_: 'kept' } };
+    expect(stripRawDeep(query)).toEqual(query);
+  });
+});

--- a/utils/functions.ts
+++ b/utils/functions.ts
@@ -16,3 +16,23 @@ export const validateCanEditTenantUser = (ctx: Context<any, UserAuthMeta>, err: 
 
 export const isInGroup = (groups: any, groupId: string) =>
   groups?.some((group: any) => group.id === Number(groupId));
+
+// Recursively remove every `$raw` key from a user-supplied query. `$raw` is
+// the `@moleculer/database` knex adapter's raw-SQL sink (`whereRaw`), and the
+// adapter recurses into every nested object/array — so stripping it only at
+// the top level is bypassed by `query[$or][0][id][$raw]`. Server-built `$raw`
+// clauses are added AFTER sanitization, so they are never seen here. Single
+// source of truth for both `profile.mixin` and `users.service`; do NOT inline
+// a second copy (a divergence would silently re-open SQL injection).
+export function stripRawDeep<T>(value: T): T {
+  if (Array.isArray(value)) return value.map(stripRawDeep) as unknown as T;
+  if (value && typeof value === 'object') {
+    const out: Record<string, any> = {};
+    for (const key of Object.keys(value)) {
+      if (key === '$raw') continue;
+      out[key] = stripRawDeep((value as Record<string, any>)[key]);
+    }
+    return out as T;
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

Multi-tenant security hardening from an audit of the whole API surface. The serious findings share **one root cause**: the gateway runs `mappingPolicy: 'all'`, so every `published` action is HTTP-reachable via the `/<service>/<action>` fallback URL (`rest: null` does **not** hide it — only `visibility: 'protected'`), while the tenant/ownership scope hooks only ran on **read** verbs (`list/find/get/count`), never `update`/`remove`/`resolve`.

Verified against the moleculer-web 0.10.6 + `@moleculer/database` source, not just by inference.

## P0 (critical)

| Hole | Exploit (any authenticated USER) | Fix |
|------|----------------------------------|-----|
| **Mass table wipe** | `POST /<svc>/removeAllEntities` → unscoped hard `DELETE FROM` of every tenant's rows | `removeAllEntities` → `visibility: 'protected'` (internal `broker.call` still works) |
| **SQL injection** | `?query[$or][0][id][$raw]=… UNION SELECT …` reached the knex `whereRaw` sink | deep-strip `$raw` at every depth (`profile.mixin` + `users.service`), extracted to a shared `stripRawDeep` util + unit test |
| **Privilege escalation** | `PATCH/POST /tenantUsers/update {role:"OWNER"}` self-promote; cross-tenant membership edits | generic `update` → `auth: ADMIN`; new `beforeRemove` guard (OWNER/USER_ADMIN + same tenant); `updateTenantUser` same-tenant check |

OWNER / USER_ADMIN keep **full edit + delete** of their own tenant's members.

## P1 (cross-tenant IDOR)

- **`ProfileMixin.beforeMutate`** ownership guard (mirrors the existing `tools.beforeDelete`) wired into `update`/`remove` **and** the `toolsGroups` `:id` custom actions (`build`/`connect`/`disconnect`/`remove`/`weigh`, which used the unscoped `toolsGroups.resolve`) across **fishings, toolsGroups, tools, weightEvents, fishingEvents, toolsGroupsEvents, researches**. A USER can no longer edit/delete another tenant's rows by id.
- **`researches.fishes`** locked to `ADMIN` over HTTP — it's internal-only (no FE consumer, no `tenant`/`user` column to scope on; managed via the INVESTIGATOR-gated `researches` service).
- **`researches.listRelated`** pinned to `publicFields` — was leaking investigator PII via caller-chosen `?fields=user,tenant&populate=user`.

## Deferred (not in this PR)

- Unauthenticated Prometheus **`/metrics` on :3030** — infra-side. Binding to `127.0.0.1` in-code risks breaking cross-container scraping, so verify `biip-infra` never proxies 3030 publicly instead.

## Testing

- New regression specs: `security-mass-delete-privesc.spec.ts`, `security-cross-tenant-idor.spec.ts`, `strip-raw-deep.spec.ts` (unit).
- Each fix asserts both the **block** (cross-tenant/USER rejected) and the **happy path** (internal call / own-tenant op still works).
- Full suite green (**196 tests**), `tsc --noEmit` + eslint + prettier clean.
- `biip-zvejyba-web` checked: it calls only guarded paths (custom actions + own-tenant CRUD), so no FE breakage. Internal `ctx.call` bypasses the gateway, so locking HTTP auth never breaks service-to-service flows.

See the new "Action exposure" + "`$raw` query operator" sections in `CLAUDE.md` for the patterns to keep this from regressing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)