### PR TITLE
fix(tenantUsers): only reassign auth group when the role actually cha…

### DIFF
--- a/services/tenantUsers.service.ts
+++ b/services/tenantUsers.service.ts
@@ -219,18 +219,28 @@ export default class TenantUsersService extends moleculer.Service {
 
     // `tenantUsers.resolve` is not tenant-scoped, so a USER_ADMIN/OWNER of one
     // tenant could otherwise pass another tenant's membership id and edit it
-    // (IDOR). Pin the target to the caller's active tenant.
-    if (String(tenantUser.tenant) !== String(profile)) {
+    // (IDOR). Pin the target to the caller's active tenant via a raw scoped
+    // lookup on the `tenantId` column (do NOT compare the serialized
+    // `tenantUser.tenant`, which can be a populated/encoded reference).
+    const ownedInTenant = await this.findEntity(ctx, {
+      query: { id, tenant: profile },
+    });
+    if (!ownedInTenant) {
       throwNoRightsError('Cannot edit a user from another tenant.');
     }
 
     const currentUser = tenantUser.user;
-    const currentTenant: Tenant = await ctx.call('tenants.resolve', {
-      throwIfNotExist: true,
-      id: profile,
-    });
 
-    if (role) {
+    // Only touch the auth group when the role ACTUALLY changes. The web form
+    // resubmits the member's current role on every email/phone edit, and a
+    // needless `auth.users.assignToGroup` (which requires auth-API group-admin
+    // rights and can 401) would then break an otherwise valid contact edit.
+    if (role && role !== tenantUser.role) {
+      const currentTenant: Tenant = await ctx.call('tenants.resolve', {
+        throwIfNotExist: true,
+        id: profile,
+      });
+
       await ctx.call('tenantUsers.update', {
         id,
         tenant: profile,

--- a/test/integration/api/security-mass-delete-privesc.spec.ts
+++ b/test/integration/api/security-mass-delete-privesc.spec.ts
@@ -235,6 +235,53 @@ describe('tenant OWNER keeps full member management (add / edit / delete)', () =
     expect(u.phone).toBe('+37061122334');
   });
 
+  it('OWNER can edit email/phone with the member`s CURRENT role (the web-form shape)', async () => {
+    // Exactly the failing real request: the form resubmits the unchanged role
+    // (`USER`) alongside new contact details. This must NOT trigger an auth
+    // group reassignment — only the contact fields change.
+    const member = await apiHelper.makeTenantMember(apiHelper.tenantA, 'USER' as any);
+    const tuId = await tenantUserId(member.user.id, apiHelper.tenantA.tenant.id);
+
+    await request(apiService.server)
+      .patch(`/zvejyba/api/tenantUsers/update/${tuId}`)
+      .set(apiHelper.getHeaders(apiHelper.ownerA.token, apiHelper.tenantA.tenant.id))
+      .send({ email: 'contact.only@test.lt', phone: '064421421', role: 'USER' })
+      .expect(200);
+
+    const u: any = await broker.call(
+      'users.resolve',
+      { id: member.user.id },
+      { meta: apiHelper.meta(apiHelper.superAdmin) },
+    );
+    expect(u.email).toBe('contact.only@test.lt');
+    expect(u.phone).toBe('064421421');
+
+    const tu: any = await broker.call(
+      'tenantUsers.resolve',
+      { id: tuId },
+      { meta: apiHelper.meta(apiHelper.superAdmin) },
+    );
+    expect(tu.role).toBe('USER');
+  });
+
+  it('OWNER can edit email/phone with NO role field at all', async () => {
+    const member = await apiHelper.makeTenantMember(apiHelper.tenantA, 'USER' as any);
+    const tuId = await tenantUserId(member.user.id, apiHelper.tenantA.tenant.id);
+
+    await request(apiService.server)
+      .patch(`/zvejyba/api/tenantUsers/update/${tuId}`)
+      .set(apiHelper.getHeaders(apiHelper.ownerA.token, apiHelper.tenantA.tenant.id))
+      .send({ email: 'norole@test.lt', phone: '+37060001112' })
+      .expect(200);
+
+    const u: any = await broker.call(
+      'users.resolve',
+      { id: member.user.id },
+      { meta: apiHelper.meta(apiHelper.superAdmin) },
+    );
+    expect(u.email).toBe('norole@test.lt');
+  });
+
   it('OWNER can DELETE a member via DELETE /tenantUsers/:id (row removed)', async () => {
     const member = await apiHelper.makeTenantMember(apiHelper.tenantA, 'USER' as any);
     const tuId = await tenantUserId(member.user.id, apiHelper.tenantA.tenant.id);


### PR DESCRIPTION
…nges

The web form resubmits a member's CURRENT role on every email/phone edit, so `updateTenantUser` always called `auth.users.assignToGroup` — which requires auth-API group-admin rights and can return 401, breaking an otherwise valid contact edit. That is why create/delete worked (they never call assignToGroup) but edit 401'd. Now the auth group is reassigned only when the role truly changes; a same-role / no-role edit just updates email+phone.

Also harden the cross-tenant ownership guard to query the raw `tenantId` column via findEntity instead of comparing the serialized `tenant` field.

The integration tests mocked the auth API (assignToGroup always succeeded), so they could not catch this — added tests for the real web-form shape (email/phone with the unchanged role, and with no role field at all).