### PR TITLE
fix(fishings): let a fisher export their own journal (not ADMIN-only)

### DIFF
--- a/services/fishings.service.ts
+++ b/services/fishings.service.ts
@@ -821,12 +821,15 @@ export default class FishTypesService extends moleculer.Service {
 
   @Action({
     rest: 'GET /exportCaughtFishes',
-    // ADMIN-only: the endpoint returns a flat Excel file with cross-row
-    // PII (createdBy.firstName/lastName). It was implicitly DEFAULT
-    // (any authenticated USER) and the inline `JSON.parse(query || {})`
-    // crashed on the empty-object fallback — both flagged by the audit
-    // (#M1).
-    auth: RestrictionType.ADMIN,
+    // DEFAULT (USER or ADMIN) — same tier as the journal `list`/`find`. The
+    // sheet is built from `fishings.find`, which runs `beforeJournalSelect`
+    // → `beforeSelect`, so a USER only ever exports their OWN tenant's rows
+    // (or, as a freelancer, their own) — exactly the journal they can already
+    // read, no cross-tenant PII. ADMIN stays unscoped (full export). The
+    // earlier #M1 ADMIN-only lock over-corrected and stopped a fisher from
+    // exporting their own journal; the `JSON.parse` guard for the `query`
+    // string (below) is the part of #M1 that we keep.
+    auth: RestrictionType.DEFAULT,
     params: {
       query: { type: 'string', optional: true },
     },

--- a/test/integration/api/security-hardening.spec.ts
+++ b/test/integration/api/security-hardening.spec.ts
@@ -2,9 +2,9 @@
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { ServiceBroker } from 'moleculer';
 import request from 'supertest';
-import { ApiHelper, serviceBrokerConfig } from '../../helpers/api';
-import { getPublicFileName } from '../../../types';
 import { coordinatesToGeometry } from '../../../modules/geometry';
+import { getPublicFileName } from '../../../types';
+import { ApiHelper, serviceBrokerConfig } from '../../helpers/api';
 
 // Regression coverage for the PR that closed /cso audit findings
 // C1-C7, H1-H5, H9 + the follow-up batch M1, M2, M4, M6, M10, M12,
@@ -275,20 +275,61 @@ describe('M16 — public UETK stats reject fish=<garbage>', () => {
   });
 });
 
-describe('M1 — fishings.exportCaughtFishes ADMIN-only + JSON validation', () => {
-  it('USER role is rejected', async () => {
+describe('M1 — fishings.exportCaughtFishes: fishers export their OWN journal + JSON validation', () => {
+  // The #M1 ADMIN-only lock over-corrected: a plain USER can read their
+  // journal but could not export it. The endpoint is now DEFAULT, and the
+  // data is sourced from the tenant-scoped `fishings.find`, so a USER only
+  // exports their own rows.
+  it('USER (fisher) CAN export their own journal (200, not 401)', async () => {
     const res = await request(apiService.server)
       .get('/zvejyba/api/fishings/exportCaughtFishes')
       .set(apiHelper.getHeaders(apiHelper.ownerA.token, apiHelper.tenantA.tenant.id));
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(200);
   });
 
-  it('ADMIN with malformed query JSON gets 422, not 500', async () => {
+  it('the export source (`fishings.find`) is tenant-scoped for a USER — no cross-tenant leak', async () => {
+    await broker.call(
+      'fishings.create',
+      {
+        type: 'INLAND_WATERS',
+        tenant: apiHelper.tenantA.tenant.id,
+        user: apiHelper.ownerA.user.id,
+      },
+      { meta: { authToken: apiHelper.superAdmin.token } },
+    );
+    await broker.call(
+      'fishings.create',
+      {
+        type: 'INLAND_WATERS',
+        tenant: apiHelper.tenantB.tenant.id,
+        user: apiHelper.ownerB.user.id,
+      },
+      { meta: { authToken: apiHelper.superAdmin.token } },
+    );
+
+    // Exactly what `exportCaughtFishes` reads, with the fisher's own meta.
+    const found: any[] = await broker.call(
+      'fishings.find',
+      {},
+      { meta: apiHelper.meta(apiHelper.ownerA, apiHelper.tenantA.tenant.id) },
+    );
+    const tenants = new Set(found.map((f) => String(f.tenant)));
+    expect(tenants.has(String(apiHelper.tenantB.tenant.id))).toBe(false);
+  });
+
+  it('USER with malformed query JSON gets 422, not 500', async () => {
     const res = await request(apiService.server)
       .get('/zvejyba/api/fishings/exportCaughtFishes')
-      .set(apiHelper.getHeaders(apiHelper.adminA.token))
+      .set(apiHelper.getHeaders(apiHelper.ownerA.token, apiHelper.tenantA.tenant.id))
       .query({ query: '{not json' });
     expect(res.status).toBe(422);
+  });
+
+  it('ADMIN can still export (unscoped, full)', async () => {
+    const res = await request(apiService.server)
+      .get('/zvejyba/api/fishings/exportCaughtFishes')
+      .set(apiHelper.getHeaders(apiHelper.adminA.token));
+    expect(res.status).toBe(200);
   });
 });
 
@@ -387,10 +428,7 @@ describe('A8 — tenantUsers app-level dedupe', () => {
     // Use tenantA — tenantB was just removed by the M4 ADMIN-delete test
     // above (specs share a broker instance, jest runs describe blocks in
     // file order). tenantA is the OWNER's home tenant and stays put.
-    const fresh = await apiHelper.makeTenantMember(
-      apiHelper.tenantA,
-      'USER' as any,
-    );
+    const fresh = await apiHelper.makeTenantMember(apiHelper.tenantA, 'USER' as any);
     await expect(
       broker.call(
         'tenantUsers.create',


### PR DESCRIPTION
## Problem (reported on staging)

A plain fisher (USER) opens the journal (`/zvejybos_zurnalas`) and clicks **export**, but `GET /fishings/exportCaughtFishes` returns **401** — only ADMIN could download the Excel.

## Root cause

A previous security pass (audit **#M1**) locked `exportCaughtFishes` to `auth: ADMIN` because the sheet contains cross-row PII (`createdBy` name, company). But the sheet is built from `fishings.find`, which runs `beforeJournalSelect → beforeSelect` — i.e. it is **already tenant-scoped** for non-admins. So a USER only ever exports their **own** tenant's rows (or, as a freelancer, their own) — exactly the journal they can already read. The ADMIN lock over-corrected and blocked fishers from their own export.

## Fix

- `exportCaughtFishes` → `auth: RestrictionType.DEFAULT` (USER or ADMIN), matching the journal `list`/`find` tier.
- ADMIN stays unscoped (full export); the `JSON.parse` guard from #M1 is kept.

No new PII exposure: a USER's export is scoped to the same data as their journal list.

## Tests (updated the #M1 block)

- USER (fisher) **can** export their own journal → 200 (was asserting 401);
- the export source (`fishings.find`) stays **tenant-scoped** for a USER — a tenantB fishing is not visible to a tenantA fisher;
- malformed `query` JSON still → 422 (for a USER now);
- ADMIN still exports (unscoped).

Full suite green (216 tests), `tsc` + eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)