### PR TITLE
fishings: only auto-end fishings that have an onshore weigh-in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,8 +264,10 @@ appear without the `call` prefix (e.g. `mol $ tenants-import --dry`).
   cron (`0 0 * * *`, Europe/Vilnius) used to close EVERY open fishing
   (`endEvent: { $exists: false }`) unconditionally. Now it only auto-closes
   fishings that already have an onshore weigh-in (a `weight_events` row with
-  `tools_group_id IS NULL`); shore-less fishings (incomplete catch reports,
-  and skip-only rows) are left open for the fisher to finish. The "has any
+  `tools_group_id IS NULL` = fishOnShore). Shore-less fishings stay open —
+  including ones weighed only on the boat (`tools_group_id` set = preliminary
+  "laive" catch), incomplete reports, and skip-only rows — for the fisher to
+  finish. The "has any
   shore weight" set comes from raw SQL (numeric ids), intersected with the
   moleculer `endEvent: { $exists: false }` query via `id: { $in }` — same
   raw-SQL-for-aggregation pattern as `applyLocationFilter` /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,6 +260,17 @@ appear without the `call` prefix (e.g. `mol $ tenants-import --dry`).
 
 ## Recent fix log (worth knowing)
 
+- **endFishings cron gates on onshore weight** — the midnight `endFishings`
+  cron (`0 0 * * *`, Europe/Vilnius) used to close EVERY open fishing
+  (`endEvent: { $exists: false }`) unconditionally. Now it only auto-closes
+  fishings that already have an onshore weigh-in (a `weight_events` row with
+  `tools_group_id IS NULL`); shore-less fishings (incomplete catch reports,
+  and skip-only rows) are left open for the fisher to finish. The "has any
+  shore weight" set comes from raw SQL (numeric ids), intersected with the
+  moleculer `endEvent: { $exists: false }` query via `id: { $in }` — same
+  raw-SQL-for-aggregation pattern as `applyLocationFilter` /
+  `getManualLocationFlags`. Test: `fishings.spec.ts` → "endFishings closes
+  fishings with an onshore weigh-in but leaves shore-less ones open".
 - **mass-delete/privesc/SQLi batch** — closed three systemic holes from a
   security audit: (1) `removeAllEntities` → `visibility: 'protected'` so the
   `mappingPolicy: 'all'` fallback URL can't wipe tables; (2) nested `$raw`

--- a/services/fishings.service.ts
+++ b/services/fishings.service.ts
@@ -318,8 +318,29 @@ export default class FishTypesService extends moleculer.Service {
     visibility: 'protected',
   })
   async endFishings(ctx: Context) {
+    // Auto-close only fishings that already have an onshore weigh-in
+    // (`weight_events.tools_group_id IS NULL`). A fishing with no shore
+    // weight is an incomplete catch report — silently ending it would
+    // freeze it with no landed catch, so leave it open for the fisher to
+    // finish. Raw SQL for the "has any shore weight" aggregation dodges the
+    // secure-id / ProfileMixin-scope layering (see CLAUDE.md → "Virtual-field
+    // populate gotchas").
+    const rows: Array<{ fishing_id: number }> = await this.rawQuery(
+      ctx,
+      `SELECT DISTINCT fishing_id FROM weight_events
+         WHERE tools_group_id IS NULL AND fishing_id IS NOT NULL AND deleted_at IS NULL`,
+    );
+    const fishingIdsWithShoreWeight = rows
+      .map((r) => Number(r.fishing_id))
+      .filter(Number.isFinite);
+
+    if (!fishingIdsWithShoreWeight.length) return [];
+
     const fishings: Fishing[] = await ctx.call('fishings.find', {
-      query: { endEvent: { $exists: false } },
+      query: {
+        endEvent: { $exists: false },
+        id: { $in: fishingIdsWithShoreWeight },
+      },
     });
 
     const result = [];

--- a/test/integration/api/fishings.spec.ts
+++ b/test/integration/api/fishings.spec.ts
@@ -118,18 +118,40 @@ describe('fishings.service — start/skip/current/end flow', () => {
     expect(res.body.skipEvent).toBeTruthy();
   });
 
-  it('endFishings closes fishings with an onshore weigh-in but leaves shore-less ones open', async () => {
+  it('endFishings closes only fishings weighed on shore; boat-only or empty ones stay open', async () => {
     const ownerAMeta = apiHelper.meta(apiHelper.ownerA, apiHelper.tenantA.tenant.id);
     const ownerBMeta = apiHelper.meta(apiHelper.ownerB, apiHelper.tenantB.tenant.id);
+    const userAMeta = apiHelper.meta(apiHelper.userA, apiHelper.tenantA.tenant.id);
     const fishId = await seedFishType();
 
-    // ownerA: an open fishing with NO onshore weigh-in → must stay open (the
-    // cron never silently closes an incomplete catch report).
+    // ownerA: an open fishing with NO weigh-in at all → must stay open.
     await seedToolForOwner(apiHelper.ownerA, apiHelper.tenantA.tenant.id);
     const withoutShore: any = await broker.call(
       'fishings.startFishing',
       { type: 'INLAND_WATERS', coordinates: sampleCoords },
       { meta: ownerAMeta },
+    );
+
+    // userA: an open fishing with ONLY a boat (preliminary) weigh-in — the
+    // weight event carries a toolsGroup (tools_group_id IS NOT NULL); nothing
+    // was weighed on shore, so this fishing must ALSO stay open. This is the
+    // case the cron must NOT close: fish weighed "laive", not "krante".
+    const boatToolId = await seedToolForOwner(apiHelper.userA, apiHelper.tenantA.tenant.id);
+    const boatTool: any = await broker.call(
+      'tools.get',
+      { id: boatToolId, populate: ['toolsGroup'] },
+      { meta: userAMeta },
+    );
+    const boatToolsGroupId = boatTool.toolsGroup?.id ?? boatTool.toolsGroup;
+    const boatOnly: any = await broker.call(
+      'fishings.startFishing',
+      { type: 'INLAND_WATERS', coordinates: sampleCoords },
+      { meta: userAMeta },
+    );
+    await broker.call(
+      'weightEvents.createWeightEvent',
+      { toolsGroup: boatToolsGroupId, coordinates: sampleCoords, data: { [fishId]: 5 } },
+      { meta: userAMeta },
     );
 
     // ownerB: an open fishing WITH an onshore weigh-in (tools_group_id NULL) →
@@ -151,6 +173,7 @@ describe('fishings.service — start/skip/current/end flow', () => {
 
     expect(closedIds).toContain(String(withShore.id));
     expect(closedIds).not.toContain(String(withoutShore.id));
+    expect(closedIds).not.toContain(String(boatOnly.id));
     closed.forEach((f) => expect(f.endEvent).toBeTruthy());
 
     const stillOpen: any = await broker.call(
@@ -159,6 +182,13 @@ describe('fishings.service — start/skip/current/end flow', () => {
       { meta: ownerAMeta },
     );
     expect(stillOpen.endEvent).toBeFalsy();
+
+    const boatStillOpen: any = await broker.call(
+      'fishings.get',
+      { id: boatOnly.id },
+      { meta: userAMeta },
+    );
+    expect(boatStillOpen.endEvent).toBeFalsy();
   });
 
   it('GET /fishings/history/:id returns a sorted event list', async () => {

--- a/test/integration/api/fishings.spec.ts
+++ b/test/integration/api/fishings.spec.ts
@@ -118,18 +118,47 @@ describe('fishings.service — start/skip/current/end flow', () => {
     expect(res.body.skipEvent).toBeTruthy();
   });
 
-  it('endFishings cron action closes orphaned fishings (sets endEvent + system user)', async () => {
-    // Open one fishing for ownerB (different tenant) without closing it.
-    await seedToolForOwner(apiHelper.ownerB, apiHelper.tenantB.tenant.id);
-    await broker.call(
+  it('endFishings closes fishings with an onshore weigh-in but leaves shore-less ones open', async () => {
+    const ownerAMeta = apiHelper.meta(apiHelper.ownerA, apiHelper.tenantA.tenant.id);
+    const ownerBMeta = apiHelper.meta(apiHelper.ownerB, apiHelper.tenantB.tenant.id);
+    const fishId = await seedFishType();
+
+    // ownerA: an open fishing with NO onshore weigh-in → must stay open (the
+    // cron never silently closes an incomplete catch report).
+    await seedToolForOwner(apiHelper.ownerA, apiHelper.tenantA.tenant.id);
+    const withoutShore: any = await broker.call(
       'fishings.startFishing',
       { type: 'INLAND_WATERS', coordinates: sampleCoords },
-      { meta: apiHelper.meta(apiHelper.ownerB, apiHelper.tenantB.tenant.id) },
+      { meta: ownerAMeta },
+    );
+
+    // ownerB: an open fishing WITH an onshore weigh-in (tools_group_id NULL) →
+    // must be auto-closed even though the fisher never pressed "Baigti".
+    await seedToolForOwner(apiHelper.ownerB, apiHelper.tenantB.tenant.id);
+    const withShore: any = await broker.call(
+      'fishings.startFishing',
+      { type: 'INLAND_WATERS', coordinates: sampleCoords },
+      { meta: ownerBMeta },
+    );
+    await broker.call(
+      'weightEvents.createWeightEvent',
+      { coordinates: sampleCoords, data: { [fishId]: 5 } },
+      { meta: ownerBMeta },
     );
 
     const closed: any[] = await broker.call('fishings.endFishings');
-    expect(closed.length).toBeGreaterThan(0);
+    const closedIds = closed.map((f) => String(f.id));
+
+    expect(closedIds).toContain(String(withShore.id));
+    expect(closedIds).not.toContain(String(withoutShore.id));
     closed.forEach((f) => expect(f.endEvent).toBeTruthy());
+
+    const stillOpen: any = await broker.call(
+      'fishings.get',
+      { id: withoutShore.id },
+      { meta: ownerAMeta },
+    );
+    expect(stillOpen.endEvent).toBeFalsy();
   });
 
   it('GET /fishings/history/:id returns a sorted event list', async () => {


### PR DESCRIPTION
## What
The midnight `endFishings` cron (`0 0 * * *`, Europe/Vilnius) used to close **every** open fishing unconditionally. It now auto-closes only fishings that already have an **onshore weigh-in** — a `weight_events` row with `tools_group_id IS NULL`. Fishings with no shore weight (incomplete catch reports, skip-only rows) are left open for the fisher to finish.

## Why
Silently ending a fishing that has no landed catch froze it as "completed" with no onshore weight recorded. Auto-closing should only tidy up fishings the fisher finished reporting but forgot to end.

## Notes
- The "has any shore weight" set is read via raw SQL (numeric ids), intersected with the moleculer `endEvent: { $exists: false }` query through `id: { $in }` — same raw-SQL-for-aggregation pattern as `applyLocationFilter` / `getManualLocationFlags` (avoids the secure-id / ProfileMixin-scope layering).
- No auth/endpoint change: `endFishings` stays `visibility: 'protected'`; the SQL takes no user input.
- Test: `fishings.spec.ts` → "endFishings closes fishings with an onshore weigh-in but leaves shore-less ones open" (asserts both the closed and the still-open case). Full `fishings.spec.ts` (13) + `security-hardening.spec.ts` (39) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)