### PR TITLE
zvejyba: map USER_ADMIN to auth group-ADMIN (member management)

### DIFF
--- a/services/auth.service.ts
+++ b/services/auth.service.ts
@@ -333,7 +333,9 @@ export default class AuthService extends moleculer.Service {
     const oldTenantUser = ctx.params.oldData as TenantUser;
 
     const roleToAuthGroupRole = (role: TenantUserRole): AuthGroupRole =>
-      role === TenantUserRole.OWNER ? AuthGroupRole.ADMIN : AuthGroupRole.USER;
+      role === TenantUserRole.OWNER || role === TenantUserRole.USER_ADMIN
+        ? AuthGroupRole.ADMIN
+        : AuthGroupRole.USER;
 
     const authRole = roleToAuthGroupRole(tenantUser.role);
     const oldAuthRole = roleToAuthGroupRole(oldTenantUser.role);

--- a/services/tenantUsers.service.ts
+++ b/services/tenantUsers.service.ts
@@ -248,7 +248,9 @@ export default class TenantUsersService extends moleculer.Service {
       });
 
       const authRole =
-        role === TenantUserRole.USER_ADMIN ? AuthGroupRole.ADMIN : AuthGroupRole.USER;
+        role === TenantUserRole.OWNER || role === TenantUserRole.USER_ADMIN
+          ? AuthGroupRole.ADMIN
+          : AuthGroupRole.USER;
 
       await ctx.call('auth.users.assignToGroup', {
         id: currentUser.authUser,
@@ -327,7 +329,10 @@ export default class TenantUsersService extends moleculer.Service {
       id: tenantId,
     });
 
-    const authRole = role === TenantUserRole.OWNER ? AuthGroupRole.ADMIN : AuthGroupRole.USER;
+    const authRole =
+      role === TenantUserRole.OWNER || role === TenantUserRole.USER_ADMIN
+        ? AuthGroupRole.ADMIN
+        : AuthGroupRole.USER;
 
     const inviteData: any = {
       personalCode,


### PR DESCRIPTION
## What
Map **both `OWNER` and `USER_ADMIN`** tenant roles to `AuthGroupRole.ADMIN` in all three tenant→auth role mappings (invite, role-change, `tenantUsers.updated` event). Previously only `OWNER` → `ADMIN`, and the role-change flow even mapped `USER_ADMIN → ADMIN` / `OWNER → USER` (demoting owners).

## Why
The upcoming **biip-auth-api release** authorizes `userGroups.assign`/`unassign` (and the `usersEvartai.invite` companyId path) by **group-admin membership** (`getVisibleGroupsIds({edit:true})`) instead of the old global type gate. `biip-medziokle-api` already maps `USER_ADMIN → group-ADMIN`, so its managers pass; zvejyba mapped `USER_ADMIN → group-USER`, so a **USER_ADMIN manager would 403 on adding/removing members** once auth-api ships. This aligns zvejyba with medziokle's `roleToAuthGroupRole`.

## Notes — @LWangllix (this is the zvejyba half of the auth `assign`/`unassign` fix)
- Code only fixes **future** invites/role-changes. **7 existing `USER_ADMIN` memberships** in prod still have auth group role `USER` and need a one-time re-sync to `ADMIN` (auth `user_groups.role`). We'll run that DB fix separately after this + the auth-api release.
- No functional effect until auth-api ships the ownership guard (at current prod auth 1.4.1 the assign/unassign paths are ungated, so writing group-ADMIN early is harmless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)